### PR TITLE
🐛 (LekaUpdater): Fix Firmware compareVersion with invalidVersion

### DIFF
--- a/Apps/LekaUpdater/Sources/Libs/FirmwareManager.swift
+++ b/Apps/LekaUpdater/Sources/Libs/FirmwareManager.swift
@@ -26,9 +26,14 @@ class FirmwareManager: ObservableObject {
     public var data = Data()
 
     func compareWith(version: String) -> RobotUpdateStatus {
+        guard version.contains(".") else {
+            return .needsUpdate
+        }
+
         guard version.compare(currentVersion, options: .numeric) == .orderedAscending else {
             return .upToDate
         }
+
         return .needsUpdate
     }
 

--- a/Apps/LekaUpdater/Tests/FirmwareManager_Tests.swift
+++ b/Apps/LekaUpdater/Tests/FirmwareManager_Tests.swift
@@ -6,7 +6,7 @@ import XCTest
 
 @testable import LekaUpdater
 
-final class FileManager_Tests_compareVersion: XCTestCase {
+final class FirmwareManager_Tests_compareVersion: XCTestCase {
 
     func test_shouldReturnRobotNeedUpdate_lowerVersion() {
         let firmwareManager = FirmwareManager()
@@ -31,6 +31,15 @@ final class FileManager_Tests_compareVersion: XCTestCase {
         let robotVersion = "99.99.999"
 
         let expected = RobotUpdateStatus.upToDate
+        let actual = firmwareManager.compareWith(version: robotVersion)
+        XCTAssertEqual(expected, actual)
+    }
+    
+    func test_shouldReturnRobotNeedUpdate_invalidVersion() {
+        let firmwareManager = FirmwareManager()
+        let robotVersion = "⚠️ NO OS VERSION"
+
+        let expected = RobotUpdateStatus.needsUpdate
         let actual = firmwareManager.compareWith(version: robotVersion)
         XCTAssertEqual(expected, actual)
     }


### PR DESCRIPTION
Might happens when os version is not available, for instance robot advertising and in version 1.0.0