### PR TITLE
🩹 (LekaUpdater): Hide alert on end of update

### DIFF
--- a/Apps/LekaUpdater/Sources/ViewModel/UpdateStatusViewModel.swift
+++ b/Apps/LekaUpdater/Sources/ViewModel/UpdateStatusViewModel.swift
@@ -52,6 +52,8 @@ class UpdateStatusViewModel: ObservableObject {
         self.updateProcessController.currentStage
             .receive(on: DispatchQueue.main)
             .sink { completion in
+                self.showAlert = false
+
                 switch completion {
                     case .finished:
                         self.updatingStatus = .updateFinished


### PR DESCRIPTION
Since the main source of change of the alert is the change of charging status, it might fail to remove when update ended, by finishing normally or with an error