### PR TITLE
🐛 (LekaUpdater): Correct format for version

### DIFF
--- a/Apps/LekaUpdater/Sources/View/ConnectionView/RobotDiscoveryView.swift
+++ b/Apps/LekaUpdater/Sources/View/ConnectionView/RobotDiscoveryView.swift
@@ -111,7 +111,7 @@ struct RobotDiscoveryView: View {
     }
 
     private var robotOsVersion: some View {
-        Text("LekaOS \(discovery.osVersion)")
+        Text("LekaOS v\(discovery.osVersion)")
             .font(.caption)
             .foregroundColor(.gray)
     }

--- a/Modules/BLEKit/Examples/BLEKitExample/Sources/Views/RobotDiscoveryView.swift
+++ b/Modules/BLEKit/Examples/BLEKitExample/Sources/Views/RobotDiscoveryView.swift
@@ -55,7 +55,7 @@ struct RobotDiscoveryView: View {
                     VStack(alignment: .leading) {
                         Text(discovery.name)
                             .font(.headline)
-                        Text(discovery.osVersion)
+                        Text("v\(discovery.osVersion)")
                     }
 
                     Spacer()

--- a/Modules/BLEKit/Sources/Models/RobotDiscoveryModel.swift
+++ b/Modules/BLEKit/Sources/Models/RobotDiscoveryModel.swift
@@ -51,15 +51,15 @@ extension RobotDiscoveryModel: Equatable {
 
 private func computeVersion(version: String?, name: String) -> String {
     if let version = version {
-        return "v\(version)"
+        return "\(version)"
     }
 
     if name == "Leka" {
-        return "v1.0.0"
+        return "1.0.0"
     } else if name.contains("LK-") && name.contains("xx") {
-        return "v1.1.0"
+        return "1.1.0"
     } else if name.contains("LK-") {
-        return "v1.2.0"
+        return "1.2.0"
     } else {
         return "(n/a)"
     }


### PR DESCRIPTION
Introduced in #331, it mislead the comparison of versions