### PR TITLE
:recycle: (BLEManager): Remove unnecessary .receive(on:)

### DIFF
--- a/Modules/BLEKit/Sources/BLEManager.swift
+++ b/Modules/BLEKit/Sources/BLEManager.swift
@@ -91,8 +91,6 @@ public class BLEManager {
 
     public func connect(_ discovery: RobotDiscoveryModel) -> AnyPublisher<RobotPeripheral, Error> {
         centralManager.connect(discovery.robotPeripheral.peripheral)
-            // TODO(@ladislas): check if receive is needed here
-            .receive(on: DispatchQueue.main)
             .compactMap { peripheral in
                 self.connectedRobotPeripheral = RobotPeripheral(peripheral: peripheral)
                 return self.connectedRobotPeripheral
@@ -109,7 +107,6 @@ public class BLEManager {
 
     private func subscribeToDidConnect() {
         self.centralManager.didConnectPeripheral
-            .receive(on: DispatchQueue.main)
             .sink { peripheral in
                 self.didConnect.send(RobotPeripheral(peripheral: peripheral))
             }
@@ -118,7 +115,6 @@ public class BLEManager {
 
     private func subscribeToDidDisconnect() {
         self.centralManager.didDisconnectPeripheral
-            .receive(on: DispatchQueue.main)
             .sink { _ in
                 self.didDisconnect.send()
             }


### PR DESCRIPTION
The reason is that BLEManger should never be used directly to drive UI.
It must always be accessed through a view model of some sort that will
use .receive(on: DispatchQueue.main) to ensure thread saffety and main
thread usage for UI

See ChatGPT discussion here: https://chat.openai.com/share/c2cf5886-1415-4f3a-833a-9acf843c3856
