### PR TITLE
🚸 (LekaUpdater): Disable turning screen off during update

### DIFF
--- a/Apps/LekaUpdater/Sources/ViewModel/UpdateStatusViewModel.swift
+++ b/Apps/LekaUpdater/Sources/ViewModel/UpdateStatusViewModel.swift
@@ -5,6 +5,7 @@
 import Combine
 import Foundation
 import LocalizationKit
+import SwiftUI
 
 class UpdateStatusViewModel: ObservableObject {
 
@@ -88,6 +89,7 @@ class UpdateStatusViewModel: ObservableObject {
                                 self.errorDescription = String(l10n.update.error.unknownErrorDescription.characters)
                                 self.errorInstructions = String(l10n.update.error.unknownErrorInstructions.characters)
                         }
+                        self.onUpdateEnded()
                 }
             } receiveValue: { state in
                 switch state {
@@ -122,7 +124,13 @@ class UpdateStatusViewModel: ObservableObject {
     }
 
     public func startUpdate() {
+        UIApplication.shared.isIdleTimerDisabled = true
+
         updateProcessController.startUpdate()
+    }
+
+    private func onUpdateEnded() {
+        UIApplication.shared.isIdleTimerDisabled = false
     }
 
 }


### PR DESCRIPTION
L'application se met en veille au bout d'un certain moment, il faut aller dans les paramètres pour éviter qu'il s'y mette.

La détection de ce problème a notamment tardé parce qu'en phase de développement, l'iPad ne se verrouille tout simplement pas lorsqu'on build et run depuis XCode.