### PR TITLE
🩹 (DesignKit): Fix Leka Logo bundle access in release mode

### DIFF
--- a/Modules/DesignKit/Sources/Views/LekaLogo.swift
+++ b/Modules/DesignKit/Sources/Views/LekaLogo.swift
@@ -17,7 +17,7 @@ public struct LekaLogo: View {
     public var body: some View {
         Image(
             DesignKitAsset.Assets.lekaLogo.name,
-            bundle: Bundle(for: DesignKitResources.self)
+            bundle: DesignKitResources.bundle
         )
         .resizable()
         .aspectRatio(contentMode: .fit)


### PR DESCRIPTION
fixes #755
