### PR TITLE
🩹 (GEK): ObserveThen - Fix scaling issue, apply clipshape first

### DIFF
--- a/Modules/GameEngineKit/Sources/Exercises/ActionButton/ActionButton+Observe.swift
+++ b/Modules/GameEngineKit/Sources/Exercises/ActionButton/ActionButton+Observe.swift
@@ -90,6 +90,8 @@ struct ActionButtonObserve: View {
             if self.image.isRasterImageFile {
                 Image(uiImage: UIImage(named: self.image)!)
                     .resizable()
+                    .clipShape(RoundedRectangle(cornerRadius: 10))
+                    .scaledToFit()
                     .frame(width: 460, height: 460)
                     .clipShape(RoundedRectangle(cornerRadius: 10))
                     .modifier(AnimatableBlur(blurRadius: self.imageWasTapped ? 0 : 20))


### PR DESCRIPTION
we display the image in a square of 460 by 460 pixels.
some images are rectangles, so we need to scale them to fit the frame.
fit is used instead of fill to make sure all the image is visible

we must apply the clipshape(RoundedRectangle) before the scaledToFit to
make sure it is visible.
