### PR TITLE
🐛 (RobotKit): Fix robots not showing on first appear

### DIFF
--- a/Modules/RobotKit/Sources/UI/ViewModels/RobotConnectionViewModel.swift
+++ b/Modules/RobotKit/Sources/UI/ViewModels/RobotConnectionViewModel.swift
@@ -31,6 +31,10 @@ public class RobotConnectionViewModel: ObservableObject {
 
     public func scanForRobots() {
         log.info("🔵 BLE - Start scanning for robots")
+        // ? On first appear, scan is not working because it is called twice.
+        // ? Setting it to nil first fixes the issues.
+        // TODO: (@leka/dev-ios) review usage of nil here to fix scan
+        self.scanCancellable = nil
         self.scanCancellable = self.bleManager.scanForRobots()
             .receive(on: DispatchQueue.main)
             .sink { _ in


### PR DESCRIPTION
On first appear, scan is called twice which causes a bug with combine
and robots are not discovered. Turning bluetooth on/off fixes the issues
but it's not a solution for our users

instead, we cancel the previous scan before starting the new one setting
the cancellable to nil
