### PR TITLE
:bug: (GEK): Do not speak if it is already speaking

### DIFF
--- a/Modules/GameEngineKit/Sources/Utils/SpeechSynthesizer.swift
+++ b/Modules/GameEngineKit/Sources/Utils/SpeechSynthesizer.swift
@@ -64,7 +64,9 @@ class SpeechSynthesizer: NSObject, AVSpeechSynthesizerDelegate, AudioPlayerProto
             return
         }
 
-        self.synthesizer.speak(self.utterance)
+        if !self.synthesizer.isSpeaking {
+            self.synthesizer.speak(self.utterance)
+        }
     }
 
     func pause() {


### PR DESCRIPTION
To avoid exception 'An AVSpeechUtterance shall not be enqueued twice'
<img width="1904" alt="Screenshot 2024-06-18 at 17 23 39" src="https://github.com/leka/ios-monorepo/assets/45776332/820bd1b7-5761-4062-9f13-574a6e04515a">

Ça arrive quand un même bouton (consigne ou action) est appuyée plusieurs fois de suite rapidement.