### PR TITLE
mathieu/refactor/migrate RootAccountManagerViewModel to Observable

### DIFF
--- a/Apps/LekaApp/Sources/Views/MainView/MainView.swift
+++ b/Apps/LekaApp/Sources/Views/MainView/MainView.swift
@@ -408,11 +408,12 @@ struct MainView: View {
     @Environment(\.scenePhase) private var scenePhase
 
     @State private var caregiverManagerViewModel = CaregiverManagerViewModel()
-    @StateObject private var rootAccountViewModel = RootAccountManagerViewModel()
 
     @State private var showingAppUpdateAlert: Bool = false
     @State private var showingOSUpdateAlert: Bool = false
     @State private var updateAlertHasBeenShown: Bool = false
+
+    @State private var rootAccountViewModel = RootAccountManagerViewModel()
 
     @Bindable private var libraryManagerViewModel: LibraryManagerViewModel = .shared
 

--- a/Modules/AccountKit/Sources/Managers/RootAccounts/RootAccountManagerViewModel.swift
+++ b/Modules/AccountKit/Sources/Managers/RootAccounts/RootAccountManagerViewModel.swift
@@ -3,9 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import Combine
+import Observation
 import SwiftUI
 
-public class RootAccountManagerViewModel: ObservableObject {
+@Observable
+public class RootAccountManagerViewModel {
     // MARK: Lifecycle
 
     public init() {
@@ -14,12 +16,12 @@ public class RootAccountManagerViewModel: ObservableObject {
 
     // MARK: Public
 
-    @Published public var errorMessage: String = ""
+    public var errorMessage: String = ""
 
     // MARK: Private
 
-    private var cancellables = Set<AnyCancellable>()
-    private let rootAccountManager = RootAccountManager.shared
+    @ObservationIgnored private var cancellables = Set<AnyCancellable>()
+    @ObservationIgnored private let rootAccountManager = RootAccountManager.shared
 
     private func subscribeToManager() {
         self.rootAccountManager.fetchErrorPublisher


### PR DESCRIPTION
- **♻️ (AccountKit): Ref. RootAccountManagerViewModel w/ Observable**
- **♻️ (LekaApp): Update MainView w/ observable RootAccountMngrVM**
