### PR TITLE
Add accessibility metadata to new activities

### DIFF
--- a/Modules/ContentKit/Resources/Content/activities/new_gamepads/gamepad_arrow_pad_big-D91BDA161F8E455CA8A71881F1D2E923.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/activities/new_gamepads/gamepad_arrow_pad_big-D91BDA161F8E455CA8A71881F1D2E923.new_activity.yml
@@ -26,6 +26,9 @@ tags:
   - sensory_stimulation
   - gamepad
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet_robot
 

--- a/Modules/ContentKit/Resources/Content/activities/new_gamepads/gamepad_arrow_pad_color_pad-5554CD696BB6492594082C5F8F895A85.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/activities/new_gamepads/gamepad_arrow_pad_color_pad-5554CD696BB6492594082C5F8F895A85.new_activity.yml
@@ -26,6 +26,9 @@ tags:
   - sensory_stimulation
   - gamepad
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet_robot
 

--- a/Modules/ContentKit/Resources/Content/activities/new_gamepads/gamepad_color_pad-DBA6170077AB4DBABEB05E03932BDC84.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/activities/new_gamepads/gamepad_color_pad-DBA6170077AB4DBABEB05E03932BDC84.new_activity.yml
@@ -24,6 +24,9 @@ tags:
   - sensory_stimulation
   - gamepad
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet_robot
 

--- a/Modules/ContentKit/Resources/Content/activities/new_gamepads/gamepad_joystick_color_pad-E85F0498A29047E893631397592CC444.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/activities/new_gamepads/gamepad_joystick_color_pad-E85F0498A29047E893631397592CC444.new_activity.yml
@@ -26,6 +26,9 @@ tags:
   - sensory_stimulation
   - gamepad
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet_robot
 

--- a/Modules/ContentKit/Resources/Content/activities/new_standalones/color_mediator-2CE6B5E98AFD45E0B2CD87727DB6D5C2.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/activities/new_standalones/color_mediator-2CE6B5E98AFD45E0B2CD87727DB6D5C2.new_activity.yml
@@ -24,6 +24,9 @@ tags:
   - colors
   - robot_colors
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/activities/new_standalones/color_music_pad-8439D1EE7DD846ACB048145089F34C33.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/activities/new_standalones/color_music_pad-8439D1EE7DD846ACB048145089F34C33.new_activity.yml
@@ -26,6 +26,9 @@ tags:
   - robot_colors
   - sensory_stimulation
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet_robot
 

--- a/Modules/ContentKit/Resources/Content/activities/new_standalones/dance_freeze-6E2F7D56726C419EA534C614F777D934.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/activities/new_standalones/dance_freeze-6E2F7D56726C419EA534C614F777D934.new_activity.yml
@@ -32,6 +32,9 @@ tags:
   - robot_movements
   - robot_colors
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/activities/new_standalones/discover_leka-89CEA9FE20624659B1307B633641BC90.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/activities/new_standalones/discover_leka-89CEA9FE20624659B1307B633641BC90.new_activity.yml
@@ -26,6 +26,9 @@ tags:
   - robot_colors
   - robot_movements
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/activities/new_standalones/hide_and_seek-4BFA2AC3390E49248DD022E27008F118.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/activities/new_standalones/hide_and_seek-4BFA2AC3390E49248DD022E27008F118.new_activity.yml
@@ -27,6 +27,9 @@ tags:
   - standalone_activity
   - sensory_stimulation
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/activities/new_standalones/melody-CB995F829411449AB32E6B8A688E3DDB.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/activities/new_standalones/melody-CB995F829411449AB32E6B8A688E3DDB.new_activity.yml
@@ -30,6 +30,9 @@ tags:
   - standalone_activity
   - sensory_stimulation
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet_robot
 

--- a/Modules/ContentKit/Resources/Content/activities/new_standalones/super_simon_2_colors-3E4B57F536824F1087A2E512223EF7E0.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/activities/new_standalones/super_simon_2_colors-3E4B57F536824F1087A2E512223EF7E0.new_activity.yml
@@ -26,6 +26,9 @@ tags:
   - robot_colors
   - sensory_stimulation
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet_robot
 

--- a/Modules/ContentKit/Resources/Content/activities/new_standalones/super_simon_4_colors-B39DDA35800849F7A40F651E411D30CD.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/activities/new_standalones/super_simon_4_colors-B39DDA35800849F7A40F651E411D30CD.new_activity.yml
@@ -26,6 +26,9 @@ tags:
   - robot_colors
   - sensory_stimulation
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet_robot
 

--- a/Modules/ContentKit/Resources/Content/activities/new_standalones/super_simon_6_colors-9EFAAC01288F41C0ACACCA5094FAD8E7.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/activities/new_standalones/super_simon_6_colors-9EFAAC01288F41C0ACACCA5094FAD8E7.new_activity.yml
@@ -26,6 +26,9 @@ tags:
   - robot_colors
   - sensory_stimulation
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet_robot
 

--- a/Modules/ContentKit/Resources/Content/activities/new_standalones/xylophone_heptatonic-65193102AE2947439ABB82D5891EDDBA.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/activities/new_standalones/xylophone_heptatonic-65193102AE2947439ABB82D5891EDDBA.new_activity.yml
@@ -26,6 +26,9 @@ tags:
   - robot_colors
   - sensory_stimulation
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet_robot
 

--- a/Modules/ContentKit/Resources/Content/activities/new_standalones/xylophone_pentatonic-7C1DDED6C6D44913B9A7D4EB4AEE8F6B.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/activities/new_standalones/xylophone_pentatonic-7C1DDED6C6D44913B9A7D4EB4AEE8F6B.new_activity.yml
@@ -24,6 +24,9 @@ tags:
   - music
   - standalone_activity
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet_robot
 

--- a/Modules/ContentKit/Resources/Content/activities/new_templates/0_touch_to_select_0_find_the_right_answers-F8C90919AF204155A170D3957BABE7D6.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/activities/new_templates/0_touch_to_select_0_find_the_right_answers-F8C90919AF204155A170D3957BABE7D6.new_activity.yml
@@ -20,6 +20,9 @@ skills: []
 tags:
   - template
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/activities/new_templates/0_touch_to_select_1_find_the_right_order-7B4F2DD1D4D3493EB73E18C37A5A607B.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/activities/new_templates/0_touch_to_select_1_find_the_right_order-7B4F2DD1D4D3493EB73E18C37A5A607B.new_activity.yml
@@ -20,6 +20,9 @@ skills: []
 tags:
   - template
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/activities/new_templates/0_touch_to_select_2_associate_categories-2D4B8496046D4A86ABA77A7EC8720ABA.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/activities/new_templates/0_touch_to_select_2_associate_categories-2D4B8496046D4A86ABA77A7EC8720ABA.new_activity.yml
@@ -20,6 +20,9 @@ skills: []
 tags:
   - template
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/activities/new_templates/drag_and_drop_in_order_vanilla-992B779C2B584CD1924F44103192FF4A.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/activities/new_templates/drag_and_drop_in_order_vanilla-992B779C2B584CD1924F44103192FF4A.new_activity.yml
@@ -20,6 +20,9 @@ skills: []
 tags:
   - template
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/activities/new_templates/drag_and_drop_into_zones_action_listen-D0628D4F8E824B85A630DAD51E7EFA6F.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/activities/new_templates/drag_and_drop_into_zones_action_listen-D0628D4F8E824B85A630DAD51E7EFA6F.new_activity.yml
@@ -20,6 +20,10 @@ skills: []
 tags:
   - template
 
+accessibility:
+  - gesture: drag_and_drop
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/activities/new_templates/drag_and_drop_into_zones_action_observe-5FAFAED40887445CAC2FCCD71B04EE0A.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/activities/new_templates/drag_and_drop_into_zones_action_observe-5FAFAED40887445CAC2FCCD71B04EE0A.new_activity.yml
@@ -20,6 +20,10 @@ skills: []
 tags:
   - template
 
+accessibility:
+  - gesture: drag_and_drop
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/activities/new_templates/drag_and_drop_into_zones_action_robot-D4E1740ED3BA427F90E697F026838A55.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/activities/new_templates/drag_and_drop_into_zones_action_robot-D4E1740ED3BA427F90E697F026838A55.new_activity.yml
@@ -20,6 +20,10 @@ skills: []
 tags:
   - template
 
+accessibility:
+  - gesture: drag_and_drop
+  - focus: robot
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/activities/new_templates/drag_and_drop_into_zones_vanilla-B71AC551EB514C32819C5ECCAED89D2A.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/activities/new_templates/drag_and_drop_into_zones_vanilla-B71AC551EB514C32819C5ECCAED89D2A.new_activity.yml
@@ -20,6 +20,9 @@ skills: []
 tags:
   - template
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/activities/new_templates/drag_and_drop_to_associate_action_listen-6514B0AAFB764F73AE999A0889C22942.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/activities/new_templates/drag_and_drop_to_associate_action_listen-6514B0AAFB764F73AE999A0889C22942.new_activity.yml
@@ -20,6 +20,10 @@ skills: []
 tags:
   - template
 
+accessibility:
+  - gesture: drag_and_drop
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/activities/new_templates/drag_and_drop_to_associate_action_observe-CD7A08C84F4140C8B03815EF53264596.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/activities/new_templates/drag_and_drop_to_associate_action_observe-CD7A08C84F4140C8B03815EF53264596.new_activity.yml
@@ -20,6 +20,10 @@ skills: []
 tags:
   - template
 
+accessibility:
+  - gesture: drag_and_drop
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/activities/new_templates/drag_and_drop_to_associate_action_robot-0EE9A795E541434C972A5DD1D27CDB8D.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/activities/new_templates/drag_and_drop_to_associate_action_robot-0EE9A795E541434C972A5DD1D27CDB8D.new_activity.yml
@@ -20,6 +20,10 @@ skills: []
 tags:
   - template
 
+accessibility:
+  - gesture: drag_and_drop
+  - focus: robot
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/activities/new_templates/drag_and_drop_to_associate_vanilla-65ACB28373384E0099D55DF2E3F3F807.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/activities/new_templates/drag_and_drop_to_associate_vanilla-65ACB28373384E0099D55DF2E3F3F807.new_activity.yml
@@ -20,6 +20,9 @@ skills: []
 tags:
   - template
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/activities/new_templates/memory-E87FFF7844134321A4392D7849A4F67F.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/activities/new_templates/memory-E87FFF7844134321A4392D7849A4F67F.new_activity.yml
@@ -20,6 +20,9 @@ skills: []
 tags:
   - template
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/activities/new_templates/touch_to_select_action_listen-285C9F3688324DFEB5298D89648FD63A.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/activities/new_templates/touch_to_select_action_listen-285C9F3688324DFEB5298D89648FD63A.new_activity.yml
@@ -20,6 +20,10 @@ skills: []
 tags:
   - template
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/activities/new_templates/touch_to_select_action_observe-70A14CC4CD394CDBB4886A8DFE4C5CCC.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/activities/new_templates/touch_to_select_action_observe-70A14CC4CD394CDBB4886A8DFE4C5CCC.new_activity.yml
@@ -20,6 +20,10 @@ skills: []
 tags:
   - template
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/activities/new_templates/touch_to_select_action_robot-92E9C1A54D8C4110878EFF39E8F2C9AD.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/activities/new_templates/touch_to_select_action_robot-92E9C1A54D8C4110878EFF39E8F2C9AD.new_activity.yml
@@ -20,6 +20,10 @@ skills: []
 tags:
   - template
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: robot
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/activities/new_templates/touch_to_select_vanilla-5930CCA4BD35409696E6FABB5844DCF2.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/activities/new_templates/touch_to_select_vanilla-5930CCA4BD35409696E6FABB5844DCF2.new_activity.yml
@@ -20,6 +20,9 @@ skills: []
 tags:
   - template
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/color_bingo-69760D1DA61849E3926E3A939BBEF0CE/new_activities/color_bingo_1-CBBCDFA8DC8C462794904F6E5E0638AB.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/color_bingo-69760D1DA61849E3926E3A939BBEF0CE/new_activities/color_bingo_1-CBBCDFA8DC8C462794904F6E5E0638AB.new_activity.yml
@@ -25,6 +25,10 @@ tags:
   - colors
   - robot_colors
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: robot
+
 hmi:
   - tablet_robot
 

--- a/Modules/ContentKit/Resources/Content/curriculums/color_bingo-69760D1DA61849E3926E3A939BBEF0CE/new_activities/color_bingo_2-7960FD995EDC4C179A4BA4997E4C5A4F.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/color_bingo-69760D1DA61849E3926E3A939BBEF0CE/new_activities/color_bingo_2-7960FD995EDC4C179A4BA4997E4C5A4F.new_activity.yml
@@ -25,6 +25,10 @@ tags:
   - colors
   - robot_colors
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: robot
+
 hmi:
   - tablet_robot
 

--- a/Modules/ContentKit/Resources/Content/curriculums/color_bingo-69760D1DA61849E3926E3A939BBEF0CE/new_activities/color_bingo_3-E742B4AF67204DA68C08ADEC6126648E.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/color_bingo-69760D1DA61849E3926E3A939BBEF0CE/new_activities/color_bingo_3-E742B4AF67204DA68C08ADEC6126648E.new_activity.yml
@@ -25,6 +25,10 @@ tags:
   - colors
   - robot_colors
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: robot
+
 hmi:
   - tablet_robot
 

--- a/Modules/ContentKit/Resources/Content/curriculums/color_bingo-69760D1DA61849E3926E3A939BBEF0CE/new_activities/color_bingo_4-A7584D692B23422BB12683FA7BE393BE.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/color_bingo-69760D1DA61849E3926E3A939BBEF0CE/new_activities/color_bingo_4-A7584D692B23422BB12683FA7BE393BE.new_activity.yml
@@ -25,6 +25,10 @@ tags:
   - colors
   - robot_colors
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: robot
+
 hmi:
   - tablet_robot
 

--- a/Modules/ContentKit/Resources/Content/curriculums/color_bingo-69760D1DA61849E3926E3A939BBEF0CE/new_activities/color_bingo_5-651AD9E7F59249EFA3A48F23A78134A2.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/color_bingo-69760D1DA61849E3926E3A939BBEF0CE/new_activities/color_bingo_5-651AD9E7F59249EFA3A48F23A78134A2.new_activity.yml
@@ -25,6 +25,10 @@ tags:
   - colors
   - robot_colors
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: robot
+
 hmi:
   - tablet_robot
 

--- a/Modules/ContentKit/Resources/Content/curriculums/color_bingo-69760D1DA61849E3926E3A939BBEF0CE/new_activities/color_bingo_6-EFC7F64F51FD4D68863749C1C278BD1F.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/color_bingo-69760D1DA61849E3926E3A939BBEF0CE/new_activities/color_bingo_6-EFC7F64F51FD4D68863749C1C278BD1F.new_activity.yml
@@ -25,6 +25,10 @@ tags:
   - colors
   - robot_colors
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: robot
+
 hmi:
   - tablet_robot
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_1-C157BAD4AA044EE89A941B1D868FFEB7/new_activities/alphabet_letters_sounds_1_1-D6ACD78BABBE4A529BDDDA84CF4FC904.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_1-C157BAD4AA044EE89A941B1D868FFEB7/new_activities/alphabet_letters_sounds_1_1-D6ACD78BABBE4A529BDDDA84CF4FC904.new_activity.yml
@@ -23,6 +23,10 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_1-C157BAD4AA044EE89A941B1D868FFEB7/new_activities/alphabet_letters_sounds_1_2-5A80D24D7D7840EC9B14269CD696C89C.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_1-C157BAD4AA044EE89A941B1D868FFEB7/new_activities/alphabet_letters_sounds_1_2-5A80D24D7D7840EC9B14269CD696C89C.new_activity.yml
@@ -23,6 +23,10 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_1-C157BAD4AA044EE89A941B1D868FFEB7/new_activities/alphabet_letters_sounds_1_4-F5B64DFCC3324CB985EFEA26B7273E72.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_1-C157BAD4AA044EE89A941B1D868FFEB7/new_activities/alphabet_letters_sounds_1_4-F5B64DFCC3324CB985EFEA26B7273E72.new_activity.yml
@@ -23,6 +23,10 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_1-C157BAD4AA044EE89A941B1D868FFEB7/new_activities/alphabet_letters_sounds_1_6-7D5B8EB45FEC472DBF46248CE90CB7A6.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_1-C157BAD4AA044EE89A941B1D868FFEB7/new_activities/alphabet_letters_sounds_1_6-7D5B8EB45FEC472DBF46248CE90CB7A6.new_activity.yml
@@ -23,6 +23,10 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_2-7297DE7F33F840AEBDB9D61942C1EAC9/new_activities/alphabet_letters_sounds_2_1-549072BAB1484863B7B51EC00873C82E.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_2-7297DE7F33F840AEBDB9D61942C1EAC9/new_activities/alphabet_letters_sounds_2_1-549072BAB1484863B7B51EC00873C82E.new_activity.yml
@@ -23,6 +23,10 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_2-7297DE7F33F840AEBDB9D61942C1EAC9/new_activities/alphabet_letters_sounds_2_2-BA1EA99BD0AA41E091A73ECF931FB6D9.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_2-7297DE7F33F840AEBDB9D61942C1EAC9/new_activities/alphabet_letters_sounds_2_2-BA1EA99BD0AA41E091A73ECF931FB6D9.new_activity.yml
@@ -23,6 +23,10 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_2-7297DE7F33F840AEBDB9D61942C1EAC9/new_activities/alphabet_letters_sounds_2_4-AC96CEBA0BA44B6FA5584D6AD4F72DFF.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_2-7297DE7F33F840AEBDB9D61942C1EAC9/new_activities/alphabet_letters_sounds_2_4-AC96CEBA0BA44B6FA5584D6AD4F72DFF.new_activity.yml
@@ -23,6 +23,10 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_2-7297DE7F33F840AEBDB9D61942C1EAC9/new_activities/alphabet_letters_sounds_2_5-0E5F9520C82740F18B29D2307E089226.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_2-7297DE7F33F840AEBDB9D61942C1EAC9/new_activities/alphabet_letters_sounds_2_5-0E5F9520C82740F18B29D2307E089226.new_activity.yml
@@ -23,6 +23,10 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_3-6285451C82354C86910B5F3773E7D8E7/new_activities/alphabet_letters_sounds_3_1-666447DDC66D4E8EAE662D87E79E3235.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_3-6285451C82354C86910B5F3773E7D8E7/new_activities/alphabet_letters_sounds_3_1-666447DDC66D4E8EAE662D87E79E3235.new_activity.yml
@@ -23,6 +23,10 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_3-6285451C82354C86910B5F3773E7D8E7/new_activities/alphabet_letters_sounds_3_2-472063C4439340CEA5490F2344161855.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_3-6285451C82354C86910B5F3773E7D8E7/new_activities/alphabet_letters_sounds_3_2-472063C4439340CEA5490F2344161855.new_activity.yml
@@ -23,6 +23,10 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_3-6285451C82354C86910B5F3773E7D8E7/new_activities/alphabet_letters_sounds_3_4-B3CD85E5307A4DA889812CDA0191A119.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_3-6285451C82354C86910B5F3773E7D8E7/new_activities/alphabet_letters_sounds_3_4-B3CD85E5307A4DA889812CDA0191A119.new_activity.yml
@@ -23,6 +23,10 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_3-6285451C82354C86910B5F3773E7D8E7/new_activities/alphabet_letters_sounds_3_5-C9DA3BB3A05F40C19B391250D4C55DE1.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_3-6285451C82354C86910B5F3773E7D8E7/new_activities/alphabet_letters_sounds_3_5-C9DA3BB3A05F40C19B391250D4C55DE1.new_activity.yml
@@ -23,6 +23,10 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_4-AFEA06A2B0D44C6381EC7F0556A580AE/new_activities/alphabet_letters_sounds_4_1-DDB97B17C7264ADEAF766777148EF20A.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_4-AFEA06A2B0D44C6381EC7F0556A580AE/new_activities/alphabet_letters_sounds_4_1-DDB97B17C7264ADEAF766777148EF20A.new_activity.yml
@@ -23,6 +23,10 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_4-AFEA06A2B0D44C6381EC7F0556A580AE/new_activities/alphabet_letters_sounds_4_2-1C906EBA61C14DDB892244DE91B2A88C.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_4-AFEA06A2B0D44C6381EC7F0556A580AE/new_activities/alphabet_letters_sounds_4_2-1C906EBA61C14DDB892244DE91B2A88C.new_activity.yml
@@ -23,6 +23,10 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_4-AFEA06A2B0D44C6381EC7F0556A580AE/new_activities/alphabet_letters_sounds_4_4-BF16A7917F8941068F01660884B6A71A.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_4-AFEA06A2B0D44C6381EC7F0556A580AE/new_activities/alphabet_letters_sounds_4_4-BF16A7917F8941068F01660884B6A71A.new_activity.yml
@@ -23,6 +23,10 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_4-AFEA06A2B0D44C6381EC7F0556A580AE/new_activities/alphabet_letters_sounds_4_5-F564687D98664E0BABCF6D942ABFCA33.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_4-AFEA06A2B0D44C6381EC7F0556A580AE/new_activities/alphabet_letters_sounds_4_5-F564687D98664E0BABCF6D942ABFCA33.new_activity.yml
@@ -23,6 +23,10 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_5-EB625985B0CD4510A1DCC8CECE1996C4/new_activities/alphabet_letters_sounds_5_1-4FFCFD05617C4C18B868084E084EA373.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_5-EB625985B0CD4510A1DCC8CECE1996C4/new_activities/alphabet_letters_sounds_5_1-4FFCFD05617C4C18B868084E084EA373.new_activity.yml
@@ -23,6 +23,10 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_5-EB625985B0CD4510A1DCC8CECE1996C4/new_activities/alphabet_letters_sounds_5_2-1B1F7F3867BA4320AF017473B58CD09E.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_5-EB625985B0CD4510A1DCC8CECE1996C4/new_activities/alphabet_letters_sounds_5_2-1B1F7F3867BA4320AF017473B58CD09E.new_activity.yml
@@ -23,6 +23,10 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_5-EB625985B0CD4510A1DCC8CECE1996C4/new_activities/alphabet_letters_sounds_5_4-60E91C4773FC4E35858392932F5F87ED.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_5-EB625985B0CD4510A1DCC8CECE1996C4/new_activities/alphabet_letters_sounds_5_4-60E91C4773FC4E35858392932F5F87ED.new_activity.yml
@@ -23,6 +23,10 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_5-EB625985B0CD4510A1DCC8CECE1996C4/new_activities/alphabet_letters_sounds_5_5-AFC771169CD74D8F86DDDDCF95A93A97.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabet_letters_sounds_5-EB625985B0CD4510A1DCC8CECE1996C4/new_activities/alphabet_letters_sounds_5_5-AFC771169CD74D8F86DDDDCF95A93A97.new_activity.yml
@@ -23,6 +23,10 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabetical_order-F9A2F6E76AE449999B1F76AA7E2D2978/new_activities/alphabetical_order_a_to_f-A96B4F744ECB4C52914183A7993683CC.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabetical_order-F9A2F6E76AE449999B1F76AA7E2D2978/new_activities/alphabetical_order_a_to_f-A96B4F744ECB4C52914183A7993683CC.new_activity.yml
@@ -21,6 +21,9 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabetical_order-F9A2F6E76AE449999B1F76AA7E2D2978/new_activities/alphabetical_order_g_to_k-A648FEEFB3644CF380D6D537372612B8.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabetical_order-F9A2F6E76AE449999B1F76AA7E2D2978/new_activities/alphabetical_order_g_to_k-A648FEEFB3644CF380D6D537372612B8.new_activity.yml
@@ -21,6 +21,9 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabetical_order-F9A2F6E76AE449999B1F76AA7E2D2978/new_activities/alphabetical_order_l_to_p-94A6A168E2E84C41BF5825588907B17F.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabetical_order-F9A2F6E76AE449999B1F76AA7E2D2978/new_activities/alphabetical_order_l_to_p-94A6A168E2E84C41BF5825588907B17F.new_activity.yml
@@ -21,6 +21,9 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabetical_order-F9A2F6E76AE449999B1F76AA7E2D2978/new_activities/alphabetical_order_q_to_u-76F0DE13BB904748B4F42BAC74F17AB7.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabetical_order-F9A2F6E76AE449999B1F76AA7E2D2978/new_activities/alphabetical_order_q_to_u-76F0DE13BB904748B4F42BAC74F17AB7.new_activity.yml
@@ -21,6 +21,9 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabetical_order-F9A2F6E76AE449999B1F76AA7E2D2978/new_activities/alphabetical_order_v_to_z-D6246B0F0687463A9744BF1528271E3C.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_alphabetical_order-F9A2F6E76AE449999B1F76AA7E2D2978/new_activities/alphabetical_order_v_to_z-D6246B0F0687463A9744BF1528271E3C.new_activity.yml
@@ -21,6 +21,9 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_memory-7C75908B86D748A283AA080D40642BE7/new_activities/animal_memory_1_pair-2719E79159AC439086C952B1A3185727.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_memory-7C75908B86D748A283AA080D40642BE7/new_activities/animal_memory_1_pair-2719E79159AC439086C952B1A3185727.new_activity.yml
@@ -26,6 +26,9 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_memory-7C75908B86D748A283AA080D40642BE7/new_activities/animal_memory_2_pairs-35AE2B4AC44C43B6B0121AA8E482039F.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_memory-7C75908B86D748A283AA080D40642BE7/new_activities/animal_memory_2_pairs-35AE2B4AC44C43B6B0121AA8E482039F.new_activity.yml
@@ -26,6 +26,9 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_memory-7C75908B86D748A283AA080D40642BE7/new_activities/animal_memory_4_pairs-5EDEA1BEB5EC49F99B2A8DAC320D7970.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_memory-7C75908B86D748A283AA080D40642BE7/new_activities/animal_memory_4_pairs-5EDEA1BEB5EC49F99B2A8DAC320D7970.new_activity.yml
@@ -26,6 +26,9 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_farm_animals-7D02DB707DD945A38BC65BDD86D2CFEA/new_activities/animal_recognition_farm_animals_1-4719436B24BA4876804DC6A734BA7E76.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_farm_animals-7D02DB707DD945A38BC65BDD86D2CFEA/new_activities/animal_recognition_farm_animals_1-4719436B24BA4876804DC6A734BA7E76.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_farm_animals-7D02DB707DD945A38BC65BDD86D2CFEA/new_activities/animal_recognition_farm_animals_2-4FBB9C309C454DD8BF73FBC564989CF3.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_farm_animals-7D02DB707DD945A38BC65BDD86D2CFEA/new_activities/animal_recognition_farm_animals_2-4FBB9C309C454DD8BF73FBC564989CF3.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_farm_animals-7D02DB707DD945A38BC65BDD86D2CFEA/new_activities/animal_recognition_farm_animals_4-0977107F2D0B42CD8563FF12EF5EC773.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_farm_animals-7D02DB707DD945A38BC65BDD86D2CFEA/new_activities/animal_recognition_farm_animals_4-0977107F2D0B42CD8563FF12EF5EC773.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_farm_animals-7D02DB707DD945A38BC65BDD86D2CFEA/new_activities/animal_recognition_farm_animals_6-0C84A385DC1B483494978DDF212B8D2D.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_farm_animals-7D02DB707DD945A38BC65BDD86D2CFEA/new_activities/animal_recognition_farm_animals_6-0C84A385DC1B483494978DDF212B8D2D.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_forest_animals-E3C3263704DC49FE8C861DDB04E27D0B/new_activities/animal_recognition_forest_animals_1-3A4F8EBF04424890B2EBF25DA6EC531A.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_forest_animals-E3C3263704DC49FE8C861DDB04E27D0B/new_activities/animal_recognition_forest_animals_1-3A4F8EBF04424890B2EBF25DA6EC531A.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_forest_animals-E3C3263704DC49FE8C861DDB04E27D0B/new_activities/animal_recognition_forest_animals_2-AFF0A81CEC734DABA7656B61B6F967A3.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_forest_animals-E3C3263704DC49FE8C861DDB04E27D0B/new_activities/animal_recognition_forest_animals_2-AFF0A81CEC734DABA7656B61B6F967A3.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_forest_animals-E3C3263704DC49FE8C861DDB04E27D0B/new_activities/animal_recognition_forest_animals_4-DF875617328749248EA4641BEFA3278E.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_forest_animals-E3C3263704DC49FE8C861DDB04E27D0B/new_activities/animal_recognition_forest_animals_4-DF875617328749248EA4641BEFA3278E.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_forest_animals-E3C3263704DC49FE8C861DDB04E27D0B/new_activities/animal_recognition_forest_animals_6-04447C2020BB43BB911F816499FAD2DD.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_forest_animals-E3C3263704DC49FE8C861DDB04E27D0B/new_activities/animal_recognition_forest_animals_6-04447C2020BB43BB911F816499FAD2DD.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_insects-D4B717CBC9B5484490A2E86B32D400AE/new_activities/animal_recognition_insects_1-14B267712FD3424E99DFEEFE27A37463.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_insects-D4B717CBC9B5484490A2E86B32D400AE/new_activities/animal_recognition_insects_1-14B267712FD3424E99DFEEFE27A37463.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_insects-D4B717CBC9B5484490A2E86B32D400AE/new_activities/animal_recognition_insects_2-3438B5B21B334F9BA8B4A71727B93A14.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_insects-D4B717CBC9B5484490A2E86B32D400AE/new_activities/animal_recognition_insects_2-3438B5B21B334F9BA8B4A71727B93A14.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_insects-D4B717CBC9B5484490A2E86B32D400AE/new_activities/animal_recognition_insects_4-6C91CD0112EE40D8888175566C63C5BE.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_insects-D4B717CBC9B5484490A2E86B32D400AE/new_activities/animal_recognition_insects_4-6C91CD0112EE40D8888175566C63C5BE.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_insects-D4B717CBC9B5484490A2E86B32D400AE/new_activities/animal_recognition_insects_6-E4B340077B174618886FF623EEA62024.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_insects-D4B717CBC9B5484490A2E86B32D400AE/new_activities/animal_recognition_insects_6-E4B340077B174618886FF623EEA62024.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_pets-358521AE2F434D54BFFFA513ED608529/new_activities/animal_recognition_pets_1-03C46293135143BF81BA579682B9E78C.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_pets-358521AE2F434D54BFFFA513ED608529/new_activities/animal_recognition_pets_1-03C46293135143BF81BA579682B9E78C.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_pets-358521AE2F434D54BFFFA513ED608529/new_activities/animal_recognition_pets_2-898A7ACFEDE24C3EBF437CC74935A570.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_pets-358521AE2F434D54BFFFA513ED608529/new_activities/animal_recognition_pets_2-898A7ACFEDE24C3EBF437CC74935A570.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_pets-358521AE2F434D54BFFFA513ED608529/new_activities/animal_recognition_pets_4-882A7422D3FA47DAB39D8FF40D90D89E.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_pets-358521AE2F434D54BFFFA513ED608529/new_activities/animal_recognition_pets_4-882A7422D3FA47DAB39D8FF40D90D89E.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_pets-358521AE2F434D54BFFFA513ED608529/new_activities/animal_recognition_pets_6-926BFE00F78F47AB986F6969DC3BCDFE.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_pets-358521AE2F434D54BFFFA513ED608529/new_activities/animal_recognition_pets_6-926BFE00F78F47AB986F6969DC3BCDFE.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_savannah_animals-FB96DF24CDBB463E987E241FDC5BEA17/new_activities/animal_animal_recognition_savannah_animals_1-945961648A2746688D36698AD0B82F86.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_savannah_animals-FB96DF24CDBB463E987E241FDC5BEA17/new_activities/animal_animal_recognition_savannah_animals_1-945961648A2746688D36698AD0B82F86.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_savannah_animals-FB96DF24CDBB463E987E241FDC5BEA17/new_activities/animal_animal_recognition_savannah_animals_2-523C95EDD2C84DF9B4800D3E400DC6BF.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_savannah_animals-FB96DF24CDBB463E987E241FDC5BEA17/new_activities/animal_animal_recognition_savannah_animals_2-523C95EDD2C84DF9B4800D3E400DC6BF.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_savannah_animals-FB96DF24CDBB463E987E241FDC5BEA17/new_activities/animal_animal_recognition_savannah_animals_4-F0B3DACF264B4DC09B4C0AF1DBEF1515.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_savannah_animals-FB96DF24CDBB463E987E241FDC5BEA17/new_activities/animal_animal_recognition_savannah_animals_4-F0B3DACF264B4DC09B4C0AF1DBEF1515.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_savannah_animals-FB96DF24CDBB463E987E241FDC5BEA17/new_activities/animal_animal_recognition_savannah_animals_6-1F29E5D70995475BBDFC87C634626625.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_savannah_animals-FB96DF24CDBB463E987E241FDC5BEA17/new_activities/animal_animal_recognition_savannah_animals_6-1F29E5D70995475BBDFC87C634626625.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_sea_animals-ADBEC52B10B0423E96B3F08CEE042752/new_activities/animal_recognition_sea_animals_1-EC749D20F1114F78A10FCB58E49AA034.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_sea_animals-ADBEC52B10B0423E96B3F08CEE042752/new_activities/animal_recognition_sea_animals_1-EC749D20F1114F78A10FCB58E49AA034.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_sea_animals-ADBEC52B10B0423E96B3F08CEE042752/new_activities/animal_recognition_sea_animals_2-E7941F63AF9449C38932629932D62F6B.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_sea_animals-ADBEC52B10B0423E96B3F08CEE042752/new_activities/animal_recognition_sea_animals_2-E7941F63AF9449C38932629932D62F6B.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_sea_animals-ADBEC52B10B0423E96B3F08CEE042752/new_activities/animal_recognition_sea_animals_4-D1C3F1781FA3492B9871F82930DC57C2.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_sea_animals-ADBEC52B10B0423E96B3F08CEE042752/new_activities/animal_recognition_sea_animals_4-D1C3F1781FA3492B9871F82930DC57C2.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_sea_animals-ADBEC52B10B0423E96B3F08CEE042752/new_activities/animal_recognition_sea_animals_6-193DCAB9B7F74DD4B213FA2AF9A84548.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_animal_recognition_sea_animals-ADBEC52B10B0423E96B3F08CEE042752/new_activities/animal_recognition_sea_animals_6-193DCAB9B7F74DD4B213FA2AF9A84548.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_categorization_sort_through-88C512E99B61485D93A7AD8C34ED6A76/new_activities/categorization_sort_through_3_categories_of_images-3B24E59C0019409397A0238553C4E39E.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_categorization_sort_through-88C512E99B61485D93A7AD8C34ED6A76/new_activities/categorization_sort_through_3_categories_of_images-3B24E59C0019409397A0238553C4E39E.new_activity.yml
@@ -25,6 +25,9 @@ tags:
   - fruits
   - vegetables
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_categorization_sort_through-88C512E99B61485D93A7AD8C34ED6A76/new_activities/categorization_sort_through_categories_of_2_images-1B6F2B9A59A64317884FD3F6C446262C.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_categorization_sort_through-88C512E99B61485D93A7AD8C34ED6A76/new_activities/categorization_sort_through_categories_of_2_images-1B6F2B9A59A64317884FD3F6C446262C.new_activity.yml
@@ -25,6 +25,9 @@ tags:
   - fruits
   - vegetables
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_categorization_sort_through-88C512E99B61485D93A7AD8C34ED6A76/new_activities/categorization_sort_through_categories_of_3_images-6BF36182A7FB47E18CA32EC21B02D5B3.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_categorization_sort_through-88C512E99B61485D93A7AD8C34ED6A76/new_activities/categorization_sort_through_categories_of_3_images-6BF36182A7FB47E18CA32EC21B02D5B3.new_activity.yml
@@ -25,6 +25,9 @@ tags:
   - fruits
   - vegetables
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_categorization_sort_through_functional_category-64388748AF714B4880B8C7B6DD6D93F3/new_activities/categorization_sort_through_functional_category_1_image-DA072AA227724969AE41ECF7BDAA7F91.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_categorization_sort_through_functional_category-64388748AF714B4880B8C7B6DD6D93F3/new_activities/categorization_sort_through_functional_category_1_image-DA072AA227724969AE41ECF7BDAA7F91.new_activity.yml
@@ -25,6 +25,9 @@ tags:
   - everyday_objects
   - home_objects
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_categorization_sort_through_functional_category-64388748AF714B4880B8C7B6DD6D93F3/new_activities/categorization_sort_through_functional_category_2_images-F617D5D9F9D045A0B3D3FFE04FA85105.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_categorization_sort_through_functional_category-64388748AF714B4880B8C7B6DD6D93F3/new_activities/categorization_sort_through_functional_category_2_images-F617D5D9F9D045A0B3D3FFE04FA85105.new_activity.yml
@@ -25,6 +25,9 @@ tags:
   - everyday_objects
   - home_objects
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_categorization_sort_through_functional_category-64388748AF714B4880B8C7B6DD6D93F3/new_activities/categorization_sort_through_functional_category_6_images-DA01E28D686943C4869F6A3CB16FA89B.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_categorization_sort_through_functional_category-64388748AF714B4880B8C7B6DD6D93F3/new_activities/categorization_sort_through_functional_category_6_images-DA01E28D686943C4869F6A3CB16FA89B.new_activity.yml
@@ -25,6 +25,9 @@ tags:
   - everyday_objects
   - home_objects
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_categorization_sort_through_functional_category-64388748AF714B4880B8C7B6DD6D93F3/new_activities/categorization_sort_through_functional_category_with_an_intruder-DB5A88B225644ABC997B86FD0E025443.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_categorization_sort_through_functional_category-64388748AF714B4880B8C7B6DD6D93F3/new_activities/categorization_sort_through_functional_category_with_an_intruder-DB5A88B225644ABC997B86FD0E025443.new_activity.yml
@@ -25,6 +25,9 @@ tags:
   - everyday_objects
   - home_objects
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_categorization_sort_through_functional_category-64388748AF714B4880B8C7B6DD6D93F3/new_activities/categorization_sort_through_functional_category_without_error-4AD006AAD458451F848DA9D3C0D1D0AD.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_categorization_sort_through_functional_category-64388748AF714B4880B8C7B6DD6D93F3/new_activities/categorization_sort_through_functional_category_without_error-4AD006AAD458451F848DA9D3C0D1D0AD.new_activity.yml
@@ -25,6 +25,9 @@ tags:
   - everyday_objects
   - home_objects
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_categorization_sorting_fruits_vegetables_basket-E6A322DC7A6E48518CED2CA2D3D2A595/new_activities/categorization_sorting_fruits_vegetables_basket_1_one_choice-A3652A06FC4F4E9081E462987106A92A.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_categorization_sorting_fruits_vegetables_basket-E6A322DC7A6E48518CED2CA2D3D2A595/new_activities/categorization_sorting_fruits_vegetables_basket_1_one_choice-A3652A06FC4F4E9081E462987106A92A.new_activity.yml
@@ -23,6 +23,9 @@ tags:
   - fruits
   - food
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_categorization_sorting_fruits_vegetables_basket-E6A322DC7A6E48518CED2CA2D3D2A595/new_activities/categorization_sorting_fruits_vegetables_basket_2_two_choices_one_intruder-7ECDDF1846AC47A8B0BEFF5525BE80B7.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_categorization_sorting_fruits_vegetables_basket-E6A322DC7A6E48518CED2CA2D3D2A595/new_activities/categorization_sorting_fruits_vegetables_basket_2_two_choices_one_intruder-7ECDDF1846AC47A8B0BEFF5525BE80B7.new_activity.yml
@@ -23,6 +23,9 @@ tags:
   - fruits
   - food
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_categorization_sorting_fruits_vegetables_basket-E6A322DC7A6E48518CED2CA2D3D2A595/new_activities/categorization_sorting_fruits_vegetables_basket_3_three_choices_multiple_intruders-88013EBEBE2E4FA6B616CF0B393F2346.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_categorization_sorting_fruits_vegetables_basket-E6A322DC7A6E48518CED2CA2D3D2A595/new_activities/categorization_sorting_fruits_vegetables_basket_3_three_choices_multiple_intruders-88013EBEBE2E4FA6B616CF0B393F2346.new_activity.yml
@@ -23,6 +23,9 @@ tags:
   - fruits
   - food
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_categorization_sorting_fruits_vegetables_basket-E6A322DC7A6E48518CED2CA2D3D2A595/new_activities/categorization_sorting_fruits_vegetables_basket_4_four_choices_same_images-58A898C6E60742BD9ED7BDB2E5AEB265.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_categorization_sorting_fruits_vegetables_basket-E6A322DC7A6E48518CED2CA2D3D2A595/new_activities/categorization_sorting_fruits_vegetables_basket_4_four_choices_same_images-58A898C6E60742BD9ED7BDB2E5AEB265.new_activity.yml
@@ -23,6 +23,9 @@ tags:
   - fruits
   - food
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_counting_candies-215DCF9CCB7B4E36A73273DC42D848E9/new_activities/counting_candies_from_1_to_5-1A3097D58288406EB4835812663D3376.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_counting_candies-215DCF9CCB7B4E36A73273DC42D848E9/new_activities/counting_candies_from_1_to_5-1A3097D58288406EB4835812663D3376.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - numbers
   - quantity
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_counting_candies-215DCF9CCB7B4E36A73273DC42D848E9/new_activities/counting_candies_from_5_to_10-1BD7331BDF0D4319B7E71AA64A16A638.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_counting_candies-215DCF9CCB7B4E36A73273DC42D848E9/new_activities/counting_candies_from_5_to_10-1BD7331BDF0D4319B7E71AA64A16A638.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - numbers
   - quantity
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_counting_flower-petals-3F83E1E0F3094DC787258B9CEEF227A1/new_activities/counting_flower_petals_from_10_to_15-A4DBB71CC24844418514D9705F651716.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_counting_flower-petals-3F83E1E0F3094DC787258B9CEEF227A1/new_activities/counting_flower_petals_from_10_to_15-A4DBB71CC24844418514D9705F651716.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - numbers
   - quantity
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_counting_flower-petals-3F83E1E0F3094DC787258B9CEEF227A1/new_activities/counting_flower_petals_from_15_to_20-B2D60F93527548ACB2695F1E56B76CAD.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_counting_flower-petals-3F83E1E0F3094DC787258B9CEEF227A1/new_activities/counting_flower_petals_from_15_to_20-B2D60F93527548ACB2695F1E56B76CAD.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - numbers
   - quantity
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_counting_robot-53E4A0E2B181472ABF3E089C833615D8/new_activities/counting_robot_animals-313569E530C243D2973F4181BD99F59C.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_counting_robot-53E4A0E2B181472ABF3E089C833615D8/new_activities/counting_robot_animals-313569E530C243D2973F4181BD99F59C.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - animals
   - numbers
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: robot
+
 hmi:
   - tablet_robot
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_counting_robot-53E4A0E2B181472ABF3E089C833615D8/new_activities/counting_robot_fruits-26652AC123BD4E1182D7105AB31FF396.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_counting_robot-53E4A0E2B181472ABF3E089C833615D8/new_activities/counting_robot_fruits-26652AC123BD4E1182D7105AB31FF396.new_activity.yml
@@ -23,8 +23,8 @@ tags:
   - numbers
 
 accessibility:
-  - gesture: mixed
-  - focus: mixed
+  - gesture: touch_to_select
+  - focus: robot
 
 hmi:
   - tablet_robot

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_counting_robot-53E4A0E2B181472ABF3E089C833615D8/new_activities/counting_robot_fruits-26652AC123BD4E1182D7105AB31FF396.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_counting_robot-53E4A0E2B181472ABF3E089C833615D8/new_activities/counting_robot_fruits-26652AC123BD4E1182D7105AB31FF396.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - fruits
   - numbers
 
+accessibility:
+  - gesture: mixed
+  - focus: mixed
+
 hmi:
   - tablet_robot
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_counting_robot-53E4A0E2B181472ABF3E089C833615D8/new_activities/counting_robot_musical_instruments-A1EFFF53AE424CCB836115C4E9911017.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_counting_robot-53E4A0E2B181472ABF3E089C833615D8/new_activities/counting_robot_musical_instruments-A1EFFF53AE424CCB836115C4E9911017.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - musical_instruments
   - numbers
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: robot
+
 hmi:
   - tablet_robot
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_find_ingredients_for_recipes-B477244ADFED4735BA1159A76E25001A.curriculum/new_activities/find_ingredients_for_recipes_with_one_intruder-79AAFFF840284DEA9D62119AB44B4796.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_find_ingredients_for_recipes-B477244ADFED4735BA1159A76E25001A.curriculum/new_activities/find_ingredients_for_recipes_with_one_intruder-79AAFFF840284DEA9D62119AB44B4796.new_activity.yml
@@ -21,6 +21,10 @@ tags:
   - food
   - cooking
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_find_ingredients_for_recipes-B477244ADFED4735BA1159A76E25001A.curriculum/new_activities/find_ingredients_for_recipes_without_intruder-FB482BC0EF6C41F7A2B0460EEFF0D689.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_find_ingredients_for_recipes-B477244ADFED4735BA1159A76E25001A.curriculum/new_activities/find_ingredients_for_recipes_without_intruder-FB482BC0EF6C41F7A2B0460EEFF0D689.new_activity.yml
@@ -21,6 +21,10 @@ tags:
   - food
   - cooking
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_fruits_and_vegetables_generalization-B6F2027A304C44F5B3C482EAFCD8DE7E/new_activities/fruits_and_vegetables_generalization_with_3_intruders-3779DB303E4F46C798AE44FA3486A86D.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_fruits_and_vegetables_generalization-B6F2027A304C44F5B3C482EAFCD8DE7E/new_activities/fruits_and_vegetables_generalization_with_3_intruders-3779DB303E4F46C798AE44FA3486A86D.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - vegetables
   - fruits
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_fruits_and_vegetables_generalization-B6F2027A304C44F5B3C482EAFCD8DE7E/new_activities/fruits_and_vegetables_generalization_without_intruder-C1980C72ED7C4789BEF7E309DD9DFF0B.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_fruits_and_vegetables_generalization-B6F2027A304C44F5B3C482EAFCD8DE7E/new_activities/fruits_and_vegetables_generalization_without_intruder-C1980C72ED7C4789BEF7E309DD9DFF0B.new_activity.yml
@@ -23,6 +23,10 @@ tags:
   - vegetables
   - fruits
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_generalization_fruits_and_vegetables_robot-053E35EB94CF4A1890489E8F2C12CE85/new_activities/generalization_fruits_robot_1-39780088085F47E0986DD91679B90027.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_generalization_fruits_and_vegetables_robot-053E35EB94CF4A1890489E8F2C12CE85/new_activities/generalization_fruits_robot_1-39780088085F47E0986DD91679B90027.new_activity.yml
@@ -17,6 +17,11 @@ skills:
   - generalization
 tags:
   - fruits
+
+accessibility:
+  - gesture: touch_to_select
+  - focus: robot
+
 hmi:
   - tablet_robot
 types:

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_generalization_fruits_and_vegetables_robot-053E35EB94CF4A1890489E8F2C12CE85/new_activities/generalization_fruits_robot_2-0BBA7068199A4CD385AFEB4FDDE0585E.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_generalization_fruits_and_vegetables_robot-053E35EB94CF4A1890489E8F2C12CE85/new_activities/generalization_fruits_robot_2-0BBA7068199A4CD385AFEB4FDDE0585E.new_activity.yml
@@ -17,6 +17,11 @@ skills:
   - generalization
 tags:
   - fruits
+
+accessibility:
+  - gesture: touch_to_select
+  - focus: robot
+
 hmi:
   - tablet_robot
 types:

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_generalization_fruits_and_vegetables_robot-053E35EB94CF4A1890489E8F2C12CE85/new_activities/generalization_vegetables_robot_1-4E074C482EA34486A8FF255F6D2B1625.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_generalization_fruits_and_vegetables_robot-053E35EB94CF4A1890489E8F2C12CE85/new_activities/generalization_vegetables_robot_1-4E074C482EA34486A8FF255F6D2B1625.new_activity.yml
@@ -16,6 +16,11 @@ skills:
   - generalization
 tags:
   - vegetables
+
+accessibility:
+  - gesture: touch_to_select
+  - focus: robot
+
 hmi:
   - tablet_robot
 types:

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_generalization_fruits_and_vegetables_robot-053E35EB94CF4A1890489E8F2C12CE85/new_activities/generalization_vegetables_robot_2-0029257BE7FB4165AA18E55DD3BCECA2.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_generalization_fruits_and_vegetables_robot-053E35EB94CF4A1890489E8F2C12CE85/new_activities/generalization_vegetables_robot_2-0029257BE7FB4165AA18E55DD3BCECA2.new_activity.yml
@@ -17,6 +17,11 @@ skills:
   - generalization
 tags:
   - vegetables
+
+accessibility:
+  - gesture: touch_to_select
+  - focus: robot
+
 hmi:
   - tablet_robot
 types:

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_leka_weather_robot-ED4C900D4ACB426384DC76F182BC19A5/new_activities/weather_with_leka_1-2CDC8A5FBA2841159F6E7E2EB262FE7F.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_leka_weather_robot-ED4C900D4ACB426384DC76F182BC19A5/new_activities/weather_with_leka_1-2CDC8A5FBA2841159F6E7E2EB262FE7F.new_activity.yml
@@ -19,6 +19,10 @@ skills:
 tags:
   - weather_elements
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: robot
+
 hmi:
   - tablet_robot
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_leka_weather_robot-ED4C900D4ACB426384DC76F182BC19A5/new_activities/weather_with_leka_2-201A137112424541B806C8F12708EA01.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_leka_weather_robot-ED4C900D4ACB426384DC76F182BC19A5/new_activities/weather_with_leka_2-201A137112424541B806C8F12708EA01.new_activity.yml
@@ -19,6 +19,10 @@ skills:
 tags:
   - weather_elements
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: robot
+
 hmi:
   - tablet_robot
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_leka_weather_robot-ED4C900D4ACB426384DC76F182BC19A5/new_activities/weather_with_leka_3-9ED6A34E56A243578284485DAB9C89BD.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_leka_weather_robot-ED4C900D4ACB426384DC76F182BC19A5/new_activities/weather_with_leka_3-9ED6A34E56A243578284485DAB9C89BD.new_activity.yml
@@ -19,6 +19,10 @@ skills:
 tags:
   - weather_elements
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: robot
+
 hmi:
   - tablet_robot
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_memory_christmas-EFC444BBDEF24E08813FF472FFA5365D/new_activities/memory_christmas_1_pair-670413A9FFAB479B90B60E7806CB9CB4.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_memory_christmas-EFC444BBDEF24E08813FF472FFA5365D/new_activities/memory_christmas_1_pair-670413A9FFAB479B90B60E7806CB9CB4.new_activity.yml
@@ -27,6 +27,9 @@ tags:
   - christmas
   - festivities
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_memory_christmas-EFC444BBDEF24E08813FF472FFA5365D/new_activities/memory_christmas_2_pairs-AB70B78D8F204726B164C8769F57A5D7.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_memory_christmas-EFC444BBDEF24E08813FF472FFA5365D/new_activities/memory_christmas_2_pairs-AB70B78D8F204726B164C8769F57A5D7.new_activity.yml
@@ -27,6 +27,9 @@ tags:
   - christmas
   - festivities
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_memory_christmas-EFC444BBDEF24E08813FF472FFA5365D/new_activities/memory_christmas_4_pairs-8877724C99E64F59941FB568E313982A.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_memory_christmas-EFC444BBDEF24E08813FF472FFA5365D/new_activities/memory_christmas_4_pairs-8877724C99E64F59941FB568E313982A.new_activity.yml
@@ -27,6 +27,9 @@ tags:
   - christmas
   - festivities
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_order_by_size_animals-1FAED1FF14134571849325B6EC9197B5/new_activities/order_by_size_animals_bear-10B482DBE5774C1E96B9A3CB36906285.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_order_by_size_animals-1FAED1FF14134571849325B6EC9197B5/new_activities/order_by_size_animals_bear-10B482DBE5774C1E96B9A3CB36906285.new_activity.yml
@@ -21,6 +21,9 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_order_by_size_animals-1FAED1FF14134571849325B6EC9197B5/new_activities/order_by_size_animals_cow-AB57AA19297D4FFE870D63B79416B7C2.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_order_by_size_animals-1FAED1FF14134571849325B6EC9197B5/new_activities/order_by_size_animals_cow-AB57AA19297D4FFE870D63B79416B7C2.new_activity.yml
@@ -21,6 +21,9 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_order_by_size_animals-1FAED1FF14134571849325B6EC9197B5/new_activities/order_by_size_animals_dolphin-1BDE26A39AB24EBB81A0EAD9D9EF2813.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_order_by_size_animals-1FAED1FF14134571849325B6EC9197B5/new_activities/order_by_size_animals_dolphin-1BDE26A39AB24EBB81A0EAD9D9EF2813.new_activity.yml
@@ -21,6 +21,9 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_order_by_size_animals-1FAED1FF14134571849325B6EC9197B5/new_activities/order_by_size_animals_fish-9EBCA72374B04D58B87A38FD699B0227.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_order_by_size_animals-1FAED1FF14134571849325B6EC9197B5/new_activities/order_by_size_animals_fish-9EBCA72374B04D58B87A38FD699B0227.new_activity.yml
@@ -21,6 +21,9 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_order_by_size_animals-1FAED1FF14134571849325B6EC9197B5/new_activities/order_by_size_animals_giraffe-62FACC5466D949BC9A6A179AE5C8D58B.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_order_by_size_animals-1FAED1FF14134571849325B6EC9197B5/new_activities/order_by_size_animals_giraffe-62FACC5466D949BC9A6A179AE5C8D58B.new_activity.yml
@@ -21,6 +21,9 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_order_by_size_animals-1FAED1FF14134571849325B6EC9197B5/new_activities/order_by_size_animals_koala-FEBEFE797DC04FDAA65C64F8935586F1.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_order_by_size_animals-1FAED1FF14134571849325B6EC9197B5/new_activities/order_by_size_animals_koala-FEBEFE797DC04FDAA65C64F8935586F1.new_activity.yml
@@ -21,6 +21,9 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_order_by_size_animals-1FAED1FF14134571849325B6EC9197B5/new_activities/order_by_size_animals_ladybug-A1E28A018A8747EAA6EA5A65CE8CAE0F.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_order_by_size_animals-1FAED1FF14134571849325B6EC9197B5/new_activities/order_by_size_animals_ladybug-A1E28A018A8747EAA6EA5A65CE8CAE0F.new_activity.yml
@@ -21,6 +21,9 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_order_by_size_animals-1FAED1FF14134571849325B6EC9197B5/new_activities/order_by_size_animals_rabbit-440AED4940AB482FB18261B44B8CE882.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_order_by_size_animals-1FAED1FF14134571849325B6EC9197B5/new_activities/order_by_size_animals_rabbit-440AED4940AB482FB18261B44B8CE882.new_activity.yml
@@ -21,6 +21,9 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_order_by_size_animals-1FAED1FF14134571849325B6EC9197B5/new_activities/order_by_size_animals_snail-645F262E4C0D447AB85D25AF251979DE.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_order_by_size_animals-1FAED1FF14134571849325B6EC9197B5/new_activities/order_by_size_animals_snail-645F262E4C0D447AB85D25AF251979DE.new_activity.yml
@@ -21,6 +21,9 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_order_by_size_animals-1FAED1FF14134571849325B6EC9197B5/new_activities/order_by_size_animals_squirrel-8D855D878B8F49E38F8EFCCBBF0B5E29.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_order_by_size_animals-1FAED1FF14134571849325B6EC9197B5/new_activities/order_by_size_animals_squirrel-8D855D878B8F49E38F8EFCCBBF0B5E29.new_activity.yml
@@ -21,6 +21,9 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_order_by_size_different_animals-3158E58D908E43D29967B04D29C21912/new_activities/order_by_size_different_animals-FDA3A9A0616B4A7382CA67529B4C76E3.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_order_by_size_different_animals-3158E58D908E43D29967B04D29C21912/new_activities/order_by_size_different_animals-FDA3A9A0616B4A7382CA67529B4C76E3.new_activity.yml
@@ -21,6 +21,9 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_ordering_of_life_stages-ADC51847C6FA4C58BA5210D02C030477/new_activities/ordering_of_life_stages_boy-660B3471643041ABA2C5994C04296809.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_ordering_of_life_stages-ADC51847C6FA4C58BA5210D02C030477/new_activities/ordering_of_life_stages_boy-660B3471643041ABA2C5994C04296809.new_activity.yml
@@ -22,6 +22,9 @@ skills:
 tags:
   - family_members
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_ordering_of_life_stages-ADC51847C6FA4C58BA5210D02C030477/new_activities/ordering_of_life_stages_girl-2DDD152B29464FF0B21DD32579EFD6B6.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_ordering_of_life_stages-ADC51847C6FA4C58BA5210D02C030477/new_activities/ordering_of_life_stages_girl-2DDD152B29464FF0B21DD32579EFD6B6.new_activity.yml
@@ -22,6 +22,9 @@ skills:
 tags:
   - family_members
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_ordering_steps_to_bake_a_cake-1F908FA3349B476DA1EE4CDC60B5B632/new_activities/ordering_the_steps_to_bake_a_cake_3-6D2AE6C2B8C149BC8203017FEC6D03DA.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_ordering_steps_to_bake_a_cake-1F908FA3349B476DA1EE4CDC60B5B632/new_activities/ordering_the_steps_to_bake_a_cake_3-6D2AE6C2B8C149BC8203017FEC6D03DA.new_activity.yml
@@ -22,6 +22,9 @@ skills:
 tags:
   - food
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_ordering_steps_to_bake_a_cake-1F908FA3349B476DA1EE4CDC60B5B632/new_activities/ordering_the_steps_to_bake_a_cake_4-D2C0BEB66B0542EAB4CBD13DF032868F.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_ordering_steps_to_bake_a_cake-1F908FA3349B476DA1EE4CDC60B5B632/new_activities/ordering_the_steps_to_bake_a_cake_4-D2C0BEB66B0542EAB4CBD13DF032868F.new_activity.yml
@@ -22,6 +22,9 @@ skills:
 tags:
   - food
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_ordering_steps_to_bake_a_cake-1F908FA3349B476DA1EE4CDC60B5B632/new_activities/ordering_the_steps_to_bake_a_cake_6-975C7C5C653F41AEBDBBC6B2FFB90C37.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_ordering_steps_to_bake_a_cake-1F908FA3349B476DA1EE4CDC60B5B632/new_activities/ordering_the_steps_to_bake_a_cake_6-975C7C5C653F41AEBDBBC6B2FFB90C37.new_activity.yml
@@ -22,6 +22,9 @@ skills:
 tags:
   - food
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_ordering_the_steps_of_a_session_with_leka-211497313FDB4094990330D2387D1CA3/new_activities/ordering_the_steps_of_a_session_with_leka_2-57384F028BBA42E08F500C84302D24FE.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_ordering_the_steps_of_a_session_with_leka-211497313FDB4094990330D2387D1CA3/new_activities/ordering_the_steps_of_a_session_with_leka_2-57384F028BBA42E08F500C84302D24FE.new_activity.yml
@@ -22,6 +22,9 @@ skills:
 tags:
   - school
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_ordering_the_steps_of_a_session_with_leka-211497313FDB4094990330D2387D1CA3/new_activities/ordering_the_steps_of_a_session_with_leka_3-48598D7E11E340DDA4643A1557D1E8BE.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_ordering_the_steps_of_a_session_with_leka-211497313FDB4094990330D2387D1CA3/new_activities/ordering_the_steps_of_a_session_with_leka_3-48598D7E11E340DDA4643A1557D1E8BE.new_activity.yml
@@ -22,6 +22,9 @@ skills:
 tags:
   - school
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_ordering_the_steps_of_a_session_with_leka-211497313FDB4094990330D2387D1CA3/new_activities/ordering_the_steps_of_a_session_with_leka_4-09DD1C400A3A45A58F6BE4765061A478.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_ordering_the_steps_of_a_session_with_leka-211497313FDB4094990330D2387D1CA3/new_activities/ordering_the_steps_of_a_session_with_leka_4-09DD1C400A3A45A58F6BE4765061A478.new_activity.yml
@@ -22,6 +22,9 @@ skills:
 tags:
   - school
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_identify_number_quantity-4499A9AFB56B4476969B96CE32F5314C/new_activities/receptive_language_identify_number_quantity_1-3E6DE6EBA1E646F1AE240012353FD227.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_identify_number_quantity-4499A9AFB56B4476969B96CE32F5314C/new_activities/receptive_language_identify_number_quantity_1-3E6DE6EBA1E646F1AE240012353FD227.new_activity.yml
@@ -26,6 +26,9 @@ tags:
   - quantity
   - digital_constellations
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_identify_objects_by_color-506EA3B894AE46EBAE4BE4AFFC65233F/new_activities/receptive_language_identify_objects_by_color_1-B8964AC4C9B644BEB35DE4B4AD1C5D93.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_identify_objects_by_color-506EA3B894AE46EBAE4BE4AFFC65233F/new_activities/receptive_language_identify_objects_by_color_1-B8964AC4C9B644BEB35DE4B4AD1C5D93.new_activity.yml
@@ -23,6 +23,9 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_identify_objects_by_color-506EA3B894AE46EBAE4BE4AFFC65233F/new_activities/receptive_language_identify_objects_by_color_with_two_components_1-95108BC74D094434AFFC34C74D95AFBC.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_identify_objects_by_color-506EA3B894AE46EBAE4BE4AFFC65233F/new_activities/receptive_language_identify_objects_by_color_with_two_components_1-95108BC74D094434AFFC34C74D95AFBC.new_activity.yml
@@ -23,6 +23,9 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_identify_objects_by_color-506EA3B894AE46EBAE4BE4AFFC65233F/new_activities/receptive_language_identify_objects_by_color_with_two_components_2-6302A027A4734264ABB0734A7822C25A.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_identify_objects_by_color-506EA3B894AE46EBAE4BE4AFFC65233F/new_activities/receptive_language_identify_objects_by_color_with_two_components_2-6302A027A4734264ABB0734A7822C25A.new_activity.yml
@@ -23,6 +23,9 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_identify_objects_by_color-506EA3B894AE46EBAE4BE4AFFC65233F/new_activities/receptive_language_identify_objects_by_color_with_two_components_3-DCF74FB8B23A4446A339231D08F85FA6.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_identify_objects_by_color-506EA3B894AE46EBAE4BE4AFFC65233F/new_activities/receptive_language_identify_objects_by_color_with_two_components_3-DCF74FB8B23A4446A339231D08F85FA6.new_activity.yml
@@ -23,6 +23,9 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_identify_objects_by_function-9B35D447AB6C402DB13BA66E4F7F4E05/new_activities/receptive_language_identify_objects_by_function_1-DD1C6FE74232465DBB5B97378AEBB430.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_identify_objects_by_function-9B35D447AB6C402DB13BA66E4F7F4E05/new_activities/receptive_language_identify_objects_by_function_1-DD1C6FE74232465DBB5B97378AEBB430.new_activity.yml
@@ -23,6 +23,9 @@ skills:
 tags:
   - everyday_objects
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_identify_objects_by_function-9B35D447AB6C402DB13BA66E4F7F4E05/new_activities/receptive_language_identify_objects_by_function_2-6020D9253EE6497A85FA7DE73C1FAEC2.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_identify_objects_by_function-9B35D447AB6C402DB13BA66E4F7F4E05/new_activities/receptive_language_identify_objects_by_function_2-6020D9253EE6497A85FA7DE73C1FAEC2.new_activity.yml
@@ -23,6 +23,9 @@ skills:
 tags:
   - everyday_objects
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_identify_opposites-5B73795D20984208AF07C4686089266E/new_activities/receptive_language_identify_opposites_clean_and_dirty_items-29CF410501F644799C18C9F970C53129.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_identify_opposites-5B73795D20984208AF07C4686089266E/new_activities/receptive_language_identify_opposites_clean_and_dirty_items-29CF410501F644799C18C9F970C53129.new_activity.yml
@@ -24,6 +24,9 @@ tags:
   - dirty
   - clean
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_identify_opposites-5B73795D20984208AF07C4686089266E/new_activities/receptive_language_identify_opposites_hot_and_cold_items-FDC6A9C523C54A47B40F2C4F1B480581.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_identify_opposites-5B73795D20984208AF07C4686089266E/new_activities/receptive_language_identify_opposites_hot_and_cold_items-FDC6A9C523C54A47B40F2C4F1B480581.new_activity.yml
@@ -24,6 +24,9 @@ tags:
   - hot
   - cold
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_identify_opposites-5B73795D20984208AF07C4686089266E/new_activities/receptive_language_identify_opposites_little_and_big_items-9309431C672C45F2946B718BAF0A8D5F.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_identify_opposites-5B73795D20984208AF07C4686089266E/new_activities/receptive_language_identify_opposites_little_and_big_items-9309431C672C45F2946B718BAF0A8D5F.new_activity.yml
@@ -24,6 +24,9 @@ tags:
   - little
   - big
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_identify_opposites-5B73795D20984208AF07C4686089266E/new_activities/receptive_language_identify_opposites_wet_and_dry_items-525A44C44F154B408244CCD3E57E77EA.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_identify_opposites-5B73795D20984208AF07C4686089266E/new_activities/receptive_language_identify_opposites_wet_and_dry_items-525A44C44F154B408244CCD3E57E77EA.new_activity.yml
@@ -24,6 +24,9 @@ tags:
   - wet
   - dry
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_identify_positional_concepts-BC1E66BCFB994A76AF09C446407D8ECF/new_activities/receptive_language_identify_positional_concepts_1-1E85ED4F09A84B48904467AC40127824.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_identify_positional_concepts-BC1E66BCFB994A76AF09C446407D8ECF/new_activities/receptive_language_identify_positional_concepts_1-1E85ED4F09A84B48904467AC40127824.new_activity.yml
@@ -29,6 +29,9 @@ tags:
   - next_to
   - on
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_identity_familiar_nouns-1607BEA72CC14285AB709C567E1BE5E7/new_activities/receptive_language_identify_familiar_nouns_with_more_than_two_syllables-AF9ACAC51F4240259050982EC15D0C7A.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_identity_familiar_nouns-1607BEA72CC14285AB709C567E1BE5E7/new_activities/receptive_language_identify_familiar_nouns_with_more_than_two_syllables-AF9ACAC51F4240259050982EC15D0C7A.new_activity.yml
@@ -23,6 +23,9 @@ skills:
 tags:
   - everyday_objects
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_identity_familiar_nouns-1607BEA72CC14285AB709C567E1BE5E7/new_activities/receptive_language_identify_familiar_nouns_with_one_syllable-49E3191F47824DEFA6011498A1B3A8AF.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_identity_familiar_nouns-1607BEA72CC14285AB709C567E1BE5E7/new_activities/receptive_language_identify_familiar_nouns_with_one_syllable-49E3191F47824DEFA6011498A1B3A8AF.new_activity.yml
@@ -23,6 +23,9 @@ skills:
 tags:
   - everyday_objects
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_identity_familiar_nouns-1607BEA72CC14285AB709C567E1BE5E7/new_activities/receptive_language_identify_familiar_nouns_with_two_syllables-353CCBCBA81247389E1086B64912273F.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_identity_familiar_nouns-1607BEA72CC14285AB709C567E1BE5E7/new_activities/receptive_language_identify_familiar_nouns_with_two_syllables-353CCBCBA81247389E1086B64912273F.new_activity.yml
@@ -23,6 +23,9 @@ skills:
 tags:
   - everyday_objects
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_ing_verbs-2B927C344CA94CD993DDB7AC4C7F46FD/new_activities/receptive_language_identify_ing_verbs_1-01BE2C6167514353964A2B9586F20E76.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_ing_verbs-2B927C344CA94CD993DDB7AC4C7F46FD/new_activities/receptive_language_identify_ing_verbs_1-01BE2C6167514353964A2B9586F20E76.new_activity.yml
@@ -23,6 +23,9 @@ skills:
 tags:
   - action_verbs
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_ing_verbs-2B927C344CA94CD993DDB7AC4C7F46FD/new_activities/receptive_language_identify_ing_verbs_2-A68EF64659D24004B254C9F924800511.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_ing_verbs-2B927C344CA94CD993DDB7AC4C7F46FD/new_activities/receptive_language_identify_ing_verbs_2-A68EF64659D24004B254C9F924800511.new_activity.yml
@@ -23,6 +23,9 @@ skills:
 tags:
   - action_verbs
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_ing_verbs-2B927C344CA94CD993DDB7AC4C7F46FD/new_activities/receptive_language_identify_ing_verbs_3-2F6BDA819A304526AA40E9573B42C6E3.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_ing_verbs-2B927C344CA94CD993DDB7AC4C7F46FD/new_activities/receptive_language_identify_ing_verbs_3-2F6BDA819A304526AA40E9573B42C6E3.new_activity.yml
@@ -23,6 +23,9 @@ skills:
 tags:
   - action_verbs
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_ing_verbs-2B927C344CA94CD993DDB7AC4C7F46FD/new_activities/receptive_language_identify_ing_verbs_with_2_components-AB832F7004D44525B90654D553355E2B.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_receptive_language_ing_verbs-2B927C344CA94CD993DDB7AC4C7F46FD/new_activities/receptive_language_identify_ing_verbs_with_2_components-AB832F7004D44525B90654D553355E2B.new_activity.yml
@@ -23,6 +23,9 @@ skills:
 tags:
   - action_verbs
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_alphabet_letters_1-27A711E56A4140C4A69FCAF0E4CD5410/new_activities/recognition_alphabet_letters_1_2-176042E5B8A14C58B2BD7AD9114960A1.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_alphabet_letters_1-27A711E56A4140C4A69FCAF0E4CD5410/new_activities/recognition_alphabet_letters_1_2-176042E5B8A14C58B2BD7AD9114960A1.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_alphabet_letters_1-27A711E56A4140C4A69FCAF0E4CD5410/new_activities/recognition_alphabet_letters_1_4-CF4CEEEA19A84D8F99F90405870CE5A3.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_alphabet_letters_1-27A711E56A4140C4A69FCAF0E4CD5410/new_activities/recognition_alphabet_letters_1_4-CF4CEEEA19A84D8F99F90405870CE5A3.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_alphabet_letters_1-27A711E56A4140C4A69FCAF0E4CD5410/new_activities/recognition_alphabet_letters_1_6-404A8AE6A4A44DD8A523DB2C522293AB.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_alphabet_letters_1-27A711E56A4140C4A69FCAF0E4CD5410/new_activities/recognition_alphabet_letters_1_6-404A8AE6A4A44DD8A523DB2C522293AB.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_alphabet_letters_2-A711CBB12FC0428CB0ACF6F1904A49AD/new_activities/recognition_alphabet_letters_2_2-33AC22ED46F34503B7B31E71B1C0C1CB.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_alphabet_letters_2-A711CBB12FC0428CB0ACF6F1904A49AD/new_activities/recognition_alphabet_letters_2_2-33AC22ED46F34503B7B31E71B1C0C1CB.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_alphabet_letters_2-A711CBB12FC0428CB0ACF6F1904A49AD/new_activities/recognition_alphabet_letters_2_4-D7896A5A863E4521B57D394E6D0BA4A2.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_alphabet_letters_2-A711CBB12FC0428CB0ACF6F1904A49AD/new_activities/recognition_alphabet_letters_2_4-D7896A5A863E4521B57D394E6D0BA4A2.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_alphabet_letters_2-A711CBB12FC0428CB0ACF6F1904A49AD/new_activities/recognition_alphabet_letters_2_6-90403905D7FB4558BD14FC6B18D5CBA2.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_alphabet_letters_2-A711CBB12FC0428CB0ACF6F1904A49AD/new_activities/recognition_alphabet_letters_2_6-90403905D7FB4558BD14FC6B18D5CBA2.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_alphabet_letters_3-ECDA68596E6A44198E66285455162A3B/new_activities/recognition_alphabet_letters_3_2-B4D3D7825AB945C7AC9629AFBA2C4C2F.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_alphabet_letters_3-ECDA68596E6A44198E66285455162A3B/new_activities/recognition_alphabet_letters_3_2-B4D3D7825AB945C7AC9629AFBA2C4C2F.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_alphabet_letters_3-ECDA68596E6A44198E66285455162A3B/new_activities/recognition_alphabet_letters_3_4-3163D0023FF145FB98A63E1F9151F53E.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_alphabet_letters_3-ECDA68596E6A44198E66285455162A3B/new_activities/recognition_alphabet_letters_3_4-3163D0023FF145FB98A63E1F9151F53E.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_alphabet_letters_3-ECDA68596E6A44198E66285455162A3B/new_activities/recognition_alphabet_letters_3_6-9EA46A7739694BDEB66958FC702BC725.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_alphabet_letters_3-ECDA68596E6A44198E66285455162A3B/new_activities/recognition_alphabet_letters_3_6-9EA46A7739694BDEB66958FC702BC725.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_alphabet_letters_4-23997B52E2C544C8AB1FA6F37F6C5409/new_activities/recognition_alphabet_letters_4_2-12C97237234C47CE93286EDBCBC14DB4.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_alphabet_letters_4-23997B52E2C544C8AB1FA6F37F6C5409/new_activities/recognition_alphabet_letters_4_2-12C97237234C47CE93286EDBCBC14DB4.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_alphabet_letters_4-23997B52E2C544C8AB1FA6F37F6C5409/new_activities/recognition_alphabet_letters_4_4-0F187A5FB5E448888634134501D30A1C.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_alphabet_letters_4-23997B52E2C544C8AB1FA6F37F6C5409/new_activities/recognition_alphabet_letters_4_4-0F187A5FB5E448888634134501D30A1C.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_alphabet_letters_4-23997B52E2C544C8AB1FA6F37F6C5409/new_activities/recognition_alphabet_letters_4_6-D255CFBB78904E16AF1825A670556F3D.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_alphabet_letters_4-23997B52E2C544C8AB1FA6F37F6C5409/new_activities/recognition_alphabet_letters_4_6-D255CFBB78904E16AF1825A670556F3D.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_alphabet_letters_5-2B6FFBF984D14AAEA7BDAD5A5456A67A/new_activities/recognition_alphabet_letters_5_2-6C29041BD30F4A56BAB5B35E1FAC7EB2.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_alphabet_letters_5-2B6FFBF984D14AAEA7BDAD5A5456A67A/new_activities/recognition_alphabet_letters_5_2-6C29041BD30F4A56BAB5B35E1FAC7EB2.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_alphabet_letters_5-2B6FFBF984D14AAEA7BDAD5A5456A67A/new_activities/recognition_alphabet_letters_5_4-AAF4E7796DAD4D418AA56A927AEB6700.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_alphabet_letters_5-2B6FFBF984D14AAEA7BDAD5A5456A67A/new_activities/recognition_alphabet_letters_5_4-AAF4E7796DAD4D418AA56A927AEB6700.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_alphabet_letters_5-2B6FFBF984D14AAEA7BDAD5A5456A67A/new_activities/recognition_alphabet_letters_5_6-FFD6023374304954B0031E8931F6B84F.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_alphabet_letters_5-2B6FFBF984D14AAEA7BDAD5A5456A67A/new_activities/recognition_alphabet_letters_5_6-FFD6023374304954B0031E8931F6B84F.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - alphabet_letters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_basic_physiological_needs-B697FEE9EF7946A2B704673FEEAA0824/new_activities/recognition_basic_physiological_needs_drawings_1_image-11EFD2C711C14CEBACD244DC9201A0ED.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_basic_physiological_needs-B697FEE9EF7946A2B704673FEEAA0824/new_activities/recognition_basic_physiological_needs_drawings_1_image-11EFD2C711C14CEBACD244DC9201A0ED.new_activity.yml
@@ -25,6 +25,10 @@ tags:
   - physiological_needs
   - oscar
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_basic_physiological_needs-B697FEE9EF7946A2B704673FEEAA0824/new_activities/recognition_basic_physiological_needs_drawings_2_images-5DBCCB46BA2B4646983BDC7160E03536.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_basic_physiological_needs-B697FEE9EF7946A2B704673FEEAA0824/new_activities/recognition_basic_physiological_needs_drawings_2_images-5DBCCB46BA2B4646983BDC7160E03536.new_activity.yml
@@ -25,6 +25,10 @@ tags:
   - physiological_needs
   - oscar
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_basic_physiological_needs-B697FEE9EF7946A2B704673FEEAA0824/new_activities/recognition_basic_physiological_needs_drawings_4_images-E06E4960B14047609C48C1E0DD6D61F2.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_basic_physiological_needs-B697FEE9EF7946A2B704673FEEAA0824/new_activities/recognition_basic_physiological_needs_drawings_4_images-E06E4960B14047609C48C1E0DD6D61F2.new_activity.yml
@@ -25,6 +25,10 @@ tags:
   - physiological_needs
   - oscar
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_bathroom_items-17AAC383297949D698AC92BD7CEC8C4C/new_activities/recognition_bathroom_items_bathroom_furniture-5A9BCAC2BE954E89A9179AFD9034BD7D.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_bathroom_items-17AAC383297949D698AC92BD7CEC8C4C/new_activities/recognition_bathroom_items_bathroom_furniture-5A9BCAC2BE954E89A9179AFD9034BD7D.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - everyday_objects
   - home_objects
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_bathroom_items-17AAC383297949D698AC92BD7CEC8C4C/new_activities/recognition_bathroom_items_health_products-64D5048EC16A4FF99D13F04D7B1CB71F.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_bathroom_items-17AAC383297949D698AC92BD7CEC8C4C/new_activities/recognition_bathroom_items_health_products-64D5048EC16A4FF99D13F04D7B1CB71F.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - everyday_objects
   - home_objects
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_bathroom_items-17AAC383297949D698AC92BD7CEC8C4C/new_activities/recognition_bathroom_items_toiletry_products-4B6E4CFBF36841008EC9DDC1E60822EF.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_bathroom_items-17AAC383297949D698AC92BD7CEC8C4C/new_activities/recognition_bathroom_items_toiletry_products-4B6E4CFBF36841008EC9DDC1E60822EF.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - everyday_objects
   - home_objects
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_bedroom_items-277B71CFDFF94C22A4F21A9C396A1501/new_activities/recognition_bedroom_items_adult_room-DA0E26666CA6480FAEC81115D12AB9CD.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_bedroom_items-277B71CFDFF94C22A4F21A9C396A1501/new_activities/recognition_bedroom_items_adult_room-DA0E26666CA6480FAEC81115D12AB9CD.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - everyday_objects
   - home_objects
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_bedroom_items-277B71CFDFF94C22A4F21A9C396A1501/new_activities/recognition_bedroom_items_child_room-6826466C1F7E443087E24C261E778549.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_bedroom_items-277B71CFDFF94C22A4F21A9C396A1501/new_activities/recognition_bedroom_items_child_room-6826466C1F7E443087E24C261E778549.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - everyday_objects
   - home_objects
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_body_parts-80761A1D62BF4C6980BF20E7D9BE52B8/new_activities/recognition_body_parts_1-756B84801C32483FABEA6E5BC5DF7081.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_body_parts-80761A1D62BF4C6980BF20E7D9BE52B8/new_activities/recognition_body_parts_1-756B84801C32483FABEA6E5BC5DF7081.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - body_parts
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_body_parts-80761A1D62BF4C6980BF20E7D9BE52B8/new_activities/recognition_body_parts_2-D9D9772CB2AE4DDFB4B718D757FA66A0.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_body_parts-80761A1D62BF4C6980BF20E7D9BE52B8/new_activities/recognition_body_parts_2-D9D9772CB2AE4DDFB4B718D757FA66A0.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - body_parts
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_body_parts-80761A1D62BF4C6980BF20E7D9BE52B8/new_activities/recognition_body_parts_4-3DFED637A5D84B8B8CE1580F2C629BE6.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_body_parts-80761A1D62BF4C6980BF20E7D9BE52B8/new_activities/recognition_body_parts_4-3DFED637A5D84B8B8CE1580F2C629BE6.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - body_parts
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_body_parts-80761A1D62BF4C6980BF20E7D9BE52B8/new_activities/recognition_body_parts_6-57A753B7CB794183AD2CD8D3CA4909A5.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_body_parts-80761A1D62BF4C6980BF20E7D9BE52B8/new_activities/recognition_body_parts_6-57A753B7CB794183AD2CD8D3CA4909A5.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - body_parts
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_christmas-DA8D769CC7C643CFA0484FAE4B22D1F7/new_activities/recognition_christmas_1-6000423931E84518BD3A840B7D2FE172.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_christmas-DA8D769CC7C643CFA0484FAE4B22D1F7/new_activities/recognition_christmas_1-6000423931E84518BD3A840B7D2FE172.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - christmas
   - festivities
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_christmas-DA8D769CC7C643CFA0484FAE4B22D1F7/new_activities/recognition_christmas_2-217B5F97C81D4E638C9E5BE8877B9C2C.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_christmas-DA8D769CC7C643CFA0484FAE4B22D1F7/new_activities/recognition_christmas_2-217B5F97C81D4E638C9E5BE8877B9C2C.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - christmas
   - festivities
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_christmas-DA8D769CC7C643CFA0484FAE4B22D1F7/new_activities/recognition_christmas_4-B89D47C18A774535AA355539709E912D.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_christmas-DA8D769CC7C643CFA0484FAE4B22D1F7/new_activities/recognition_christmas_4-B89D47C18A774535AA355539709E912D.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - christmas
   - festivities
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_cooked_fruits-C0D2DAE8152F4CAE863EAEBF815354BA/new_activities/recognition_cooked_fruits_2_images-88CA88F2E05D471E994D5F618C556D64.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_cooked_fruits-C0D2DAE8152F4CAE863EAEBF815354BA/new_activities/recognition_cooked_fruits_2_images-88CA88F2E05D471E994D5F618C556D64.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - food
   - fruits
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_cooked_fruits-C0D2DAE8152F4CAE863EAEBF815354BA/new_activities/recognition_cooked_fruits_4_images-A4B293D45223433CB45ED92275BAA0DE.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_cooked_fruits-C0D2DAE8152F4CAE863EAEBF815354BA/new_activities/recognition_cooked_fruits_4_images-A4B293D45223433CB45ED92275BAA0DE.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - food
   - fruits
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_cooked_fruits-C0D2DAE8152F4CAE863EAEBF815354BA/new_activities/recognition_cooked_fruits_6_images-372197E48EDF4EE7A9A0BB04AACB3791.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_cooked_fruits-C0D2DAE8152F4CAE863EAEBF815354BA/new_activities/recognition_cooked_fruits_6_images-372197E48EDF4EE7A9A0BB04AACB3791.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - food
   - fruits
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_cooked_vegetables-655C2A62DB644DAABC8A286025231418/new_activities/recognition_cooked_vegetables_2_images-3D84B134E4D14D8FB7FA13944B546058.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_cooked_vegetables-655C2A62DB644DAABC8A286025231418/new_activities/recognition_cooked_vegetables_2_images-3D84B134E4D14D8FB7FA13944B546058.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - food
   - vegetables
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_cooked_vegetables-655C2A62DB644DAABC8A286025231418/new_activities/recognition_cooked_vegetables_4_images-9DBCA385BE544A01B0402A7E2978CE28.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_cooked_vegetables-655C2A62DB644DAABC8A286025231418/new_activities/recognition_cooked_vegetables_4_images-9DBCA385BE544A01B0402A7E2978CE28.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - food
   - vegetables
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_cooked_vegetables-655C2A62DB644DAABC8A286025231418/new_activities/recognition_cooked_vegetables_6_images-266EFC2160C54D7FB3C9AE9750A1C4DC.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_cooked_vegetables-655C2A62DB644DAABC8A286025231418/new_activities/recognition_cooked_vegetables_6_images-266EFC2160C54D7FB3C9AE9750A1C4DC.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - food
   - vegetables
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_digital_constellations-0C50B1358BF146DBA286423A4A32A85F/new_activities/recognition_digital_constellations_dice-38D55E8E0967461AA33572A78B6AC0EA.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_digital_constellations-0C50B1358BF146DBA286423A4A32A85F/new_activities/recognition_digital_constellations_dice-38D55E8E0967461AA33572A78B6AC0EA.new_activity.yml
@@ -24,6 +24,10 @@ tags:
   - numbers
   - digital_constellations
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_digital_constellations-0C50B1358BF146DBA286423A4A32A85F/new_activities/recognition_digital_constellations_dice_numbers-A001E852147B47548B634067E6E832A9.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_digital_constellations-0C50B1358BF146DBA286423A4A32A85F/new_activities/recognition_digital_constellations_dice_numbers-A001E852147B47548B634067E6E832A9.new_activity.yml
@@ -24,6 +24,10 @@ tags:
   - numbers
   - digital_constellations
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_digital_constellations-0C50B1358BF146DBA286423A4A32A85F/new_activities/recognition_digital_constellations_objects-700B09D55E3B4AB998CEA7028D41EEA7.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_digital_constellations-0C50B1358BF146DBA286423A4A32A85F/new_activities/recognition_digital_constellations_objects-700B09D55E3B4AB998CEA7028D41EEA7.new_activity.yml
@@ -24,6 +24,10 @@ tags:
   - numbers
   - digital_constellations
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_1_hugo-D9663D6F1E9F4D228FDCD918317996A3.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_1_hugo-D9663D6F1E9F4D228FDCD918317996A3.new_activity.yml
@@ -22,6 +22,9 @@ tags:
   - emotions
   - hugo
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_1_louna-A5D3673F3D9643B29EF6F7C5CBAE73CA.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_1_louna-A5D3673F3D9643B29EF6F7C5CBAE73CA.new_activity.yml
@@ -22,6 +22,9 @@ tags:
   - emotions
   - louna
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_1_moussa-FDFB9C81374044D594DE430EB961E7DD.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_1_moussa-FDFB9C81374044D594DE430EB961E7DD.new_activity.yml
@@ -22,6 +22,9 @@ tags:
   - emotions
   - moussa
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_1_oscar-E44983B555BC44659C91605315A12C29.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_1_oscar-E44983B555BC44659C91605315A12C29.new_activity.yml
@@ -22,6 +22,9 @@ tags:
   - emotions
   - oscar
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_1_zoe-A703772398514DB298DDEF6435D787CD.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_1_zoe-A703772398514DB298DDEF6435D787CD.new_activity.yml
@@ -22,6 +22,9 @@ tags:
   - emotions
   - zoe
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_2_hugo-9459DB5E83F74AE88B86D9A961A9C331.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_2_hugo-9459DB5E83F74AE88B86D9A961A9C331.new_activity.yml
@@ -22,6 +22,9 @@ tags:
   - emotions
   - hugo
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_2_hugo_moussa-486C6B3EC7774FB4ADA8DDC8A8C4AC85.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_2_hugo_moussa-486C6B3EC7774FB4ADA8DDC8A8C4AC85.new_activity.yml
@@ -23,6 +23,9 @@ tags:
   - moussa
   - hugo
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_2_hugo_zoe-00DCB1EFAF0046BFA2421F4A71F44E98.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_2_hugo_zoe-00DCB1EFAF0046BFA2421F4A71F44E98.new_activity.yml
@@ -23,6 +23,9 @@ tags:
   - hugo
   - zoe
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_2_louna-85D74E8ED0CF4E18A29F5C7305CBEC7A.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_2_louna-85D74E8ED0CF4E18A29F5C7305CBEC7A.new_activity.yml
@@ -22,6 +22,9 @@ tags:
   - emotions
   - louna
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_2_louna_oscar-731C7519652F44408307FBA3E8353E1E.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_2_louna_oscar-731C7519652F44408307FBA3E8353E1E.new_activity.yml
@@ -23,6 +23,9 @@ tags:
   - oscar
   - louna
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_2_louna_zoe-578CA01FC1464855A98A92943A472521.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_2_louna_zoe-578CA01FC1464855A98A92943A472521.new_activity.yml
@@ -23,6 +23,9 @@ tags:
   - zoe
   - louna
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_2_moussa-E49EEAC175EA487F9BF2C767B46233DC.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_2_moussa-E49EEAC175EA487F9BF2C767B46233DC.new_activity.yml
@@ -22,6 +22,9 @@ tags:
   - emotions
   - moussa
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_2_oscar-4E509EEF60244D68BBAD610675BEEC5F.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_2_oscar-4E509EEF60244D68BBAD610675BEEC5F.new_activity.yml
@@ -22,6 +22,9 @@ tags:
   - emotions
   - oscar
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_2_oscar_hugo-A60A42C7CC1C4A2096B493D1214B7757.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_2_oscar_hugo-A60A42C7CC1C4A2096B493D1214B7757.new_activity.yml
@@ -23,6 +23,9 @@ tags:
   - hugo
   - oscar
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_2_zoe-B2E3C40835574DEC8F0FB6DBDF1B0E18.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_2_zoe-B2E3C40835574DEC8F0FB6DBDF1B0E18.new_activity.yml
@@ -22,6 +22,9 @@ tags:
   - emotions
   - zoe
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_4_all_characters-F0F6C98DA212464387B00DDD298D882A.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_4_all_characters-F0F6C98DA212464387B00DDD298D882A.new_activity.yml
@@ -26,6 +26,9 @@ tags:
   - louna
   - hugo
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_4_hugo-5FC4C6B028834D5FB10092EB0A92BFFE.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_4_hugo-5FC4C6B028834D5FB10092EB0A92BFFE.new_activity.yml
@@ -22,6 +22,9 @@ tags:
   - emotions
   - hugo
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_4_hugo_louna_moussa_oscar_zoe-6A2E053D6A1D49DB8636421A50458B6F.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_4_hugo_louna_moussa_oscar_zoe-6A2E053D6A1D49DB8636421A50458B6F.new_activity.yml
@@ -26,6 +26,9 @@ tags:
   - oscar
   - hugo
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_4_hugo_zoe-EA390CDEEEC24E279E7738107B6D68E2.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_4_hugo_zoe-EA390CDEEEC24E279E7738107B6D68E2.new_activity.yml
@@ -23,6 +23,9 @@ tags:
   - zoe
   - hugo
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_4_louna-D48FACE8648F40D2B410A8123EAAFF63.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_4_louna-D48FACE8648F40D2B410A8123EAAFF63.new_activity.yml
@@ -22,6 +22,9 @@ tags:
   - emotions
   - louna
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_4_louna_oscar-4D7B43FA50E74A6D9A1AA4C49AFC82C0.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_4_louna_oscar-4D7B43FA50E74A6D9A1AA4C49AFC82C0.new_activity.yml
@@ -23,6 +23,9 @@ tags:
   - oscar
   - louna
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_4_louna_zoe-6467C269389743B0B4846CB900E9DC2A.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_4_louna_zoe-6467C269389743B0B4846CB900E9DC2A.new_activity.yml
@@ -23,6 +23,9 @@ tags:
   - zoe
   - louna
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_4_moussa-602ADEF84FE342D48A14F4FDEE1B721C.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_4_moussa-602ADEF84FE342D48A14F4FDEE1B721C.new_activity.yml
@@ -22,6 +22,9 @@ tags:
   - emotions
   - moussa
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_4_oscar-7DBFAB2704EF4C0086BEC36BE0BC295E.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_4_oscar-7DBFAB2704EF4C0086BEC36BE0BC295E.new_activity.yml
@@ -22,6 +22,9 @@ tags:
   - emotions
   - oscar
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_4_oscar_hugo-FE48BA74BFB147DC8639C5056740BB7B.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_4_oscar_hugo-FE48BA74BFB147DC8639C5056740BB7B.new_activity.yml
@@ -23,6 +23,9 @@ tags:
   - hugo
   - oscar
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_4_oscar_moussa-5F384AC5C4E8460BAF7361793051BF79.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_4_oscar_moussa-5F384AC5C4E8460BAF7361793051BF79.new_activity.yml
@@ -23,6 +23,9 @@ tags:
   - moussa
   - oscar
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_4_zoe-7AACD460ACBD49FA88BE66182C59833D.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_drawings-95C42E189BC146BB844467A3BAFE8BC0/new_activities/recognition_emotions_drawings_4_zoe-7AACD460ACBD49FA88BE66182C59833D.new_activity.yml
@@ -22,6 +22,9 @@ tags:
   - emotions
   - zoe
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_generalization-173A0E0985D944F9835E2205867121FC/new_activities/recognition_emotions_generalization_3_images_2_types-699FB7EB68DD41F1BB24DB67B10CE60D.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_generalization-173A0E0985D944F9835E2205867121FC/new_activities/recognition_emotions_generalization_3_images_2_types-699FB7EB68DD41F1BB24DB67B10CE60D.new_activity.yml
@@ -25,6 +25,9 @@ tags:
   - characters
   - pictures
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_generalization-173A0E0985D944F9835E2205867121FC/new_activities/recognition_emotions_generalization_3_images_3_types-C21549498D584ECBBE713AD05B4225ED.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_generalization-173A0E0985D944F9835E2205867121FC/new_activities/recognition_emotions_generalization_3_images_3_types-C21549498D584ECBBE713AD05B4225ED.new_activity.yml
@@ -25,6 +25,9 @@ tags:
   - characters
   - pictures
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_generalization-173A0E0985D944F9835E2205867121FC/new_activities/recognition_emotions_generalization_4_images_2_types-DDD78773E4DC4C5BB7A478790096A2CA.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_generalization-173A0E0985D944F9835E2205867121FC/new_activities/recognition_emotions_generalization_4_images_2_types-DDD78773E4DC4C5BB7A478790096A2CA.new_activity.yml
@@ -25,6 +25,9 @@ tags:
   - characters
   - pictures
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_generalization-173A0E0985D944F9835E2205867121FC/new_activities/recognition_emotions_generalization_4_images_3_types-26E096665BE041E8BB10003D3FE08BF2.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_generalization-173A0E0985D944F9835E2205867121FC/new_activities/recognition_emotions_generalization_4_images_3_types-26E096665BE041E8BB10003D3FE08BF2.new_activity.yml
@@ -25,6 +25,9 @@ tags:
   - characters
   - pictures
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_generalization-173A0E0985D944F9835E2205867121FC/new_activities/recognition_emotions_generalization_6_images_2_types-C5677BD6215040CA8B2508465D0431D8.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_generalization-173A0E0985D944F9835E2205867121FC/new_activities/recognition_emotions_generalization_6_images_2_types-C5677BD6215040CA8B2508465D0431D8.new_activity.yml
@@ -25,6 +25,9 @@ tags:
   - characters
   - pictures
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_generalization-173A0E0985D944F9835E2205867121FC/new_activities/recognition_emotions_generalization_6_images_3_types-6E345E56197B457D8115445A2A3A8B0E.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_generalization-173A0E0985D944F9835E2205867121FC/new_activities/recognition_emotions_generalization_6_images_3_types-6E345E56197B457D8115445A2A3A8B0E.new_activity.yml
@@ -25,6 +25,9 @@ tags:
   - characters
   - pictures
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_in_context-A135163C8D8646DE95D0854FD5E155EB.curriculum/new_activities/recognition_emotions_in_context_5_emotions-ADE4BA794B6D4B42B3A39127F5DDF8D0.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_in_context-A135163C8D8646DE95D0854FD5E155EB.curriculum/new_activities/recognition_emotions_in_context_5_emotions-ADE4BA794B6D4B42B3A39127F5DDF8D0.new_activity.yml
@@ -23,6 +23,10 @@ tags:
   - emotions
   - characters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_in_context-A135163C8D8646DE95D0854FD5E155EB.curriculum/new_activities/recognition_emotions_in_context_thumbs_up_thumbs_down-95A0134AA0E04EA3B6933BDFC8564CBA.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_in_context-A135163C8D8646DE95D0854FD5E155EB.curriculum/new_activities/recognition_emotions_in_context_thumbs_up_thumbs_down-95A0134AA0E04EA3B6933BDFC8564CBA.new_activity.yml
@@ -25,6 +25,10 @@ tags:
   - thumbs_up
   - characters
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictograms-3A9B0EB3A9CF4ABCB9B771B6047DF2D0/new_activities/recognition_emotions_pictograms_1_leka-5C8987EC85064792AAA6C9DFB6B315C5.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictograms-3A9B0EB3A9CF4ABCB9B771B6047DF2D0/new_activities/recognition_emotions_pictograms_1_leka-5C8987EC85064792AAA6C9DFB6B315C5.new_activity.yml
@@ -21,6 +21,9 @@ tags:
   - leka_pictograms
   - emotions
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictograms-3A9B0EB3A9CF4ABCB9B771B6047DF2D0/new_activities/recognition_emotions_pictograms_2_leka-8AE0997C2DC843078ABE11B36F4BA56D.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictograms-3A9B0EB3A9CF4ABCB9B771B6047DF2D0/new_activities/recognition_emotions_pictograms_2_leka-8AE0997C2DC843078ABE11B36F4BA56D.new_activity.yml
@@ -21,6 +21,9 @@ tags:
   - leka_pictograms
   - emotions
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictograms-3A9B0EB3A9CF4ABCB9B771B6047DF2D0/new_activities/recognition_emotions_pictograms_3_leka-A52EDCD576DB491790C5C79683B9E83A.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictograms-3A9B0EB3A9CF4ABCB9B771B6047DF2D0/new_activities/recognition_emotions_pictograms_3_leka-A52EDCD576DB491790C5C79683B9E83A.new_activity.yml
@@ -21,6 +21,9 @@ tags:
   - leka_pictograms
   - emotions
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictograms-3A9B0EB3A9CF4ABCB9B771B6047DF2D0/new_activities/recognition_emotions_pictograms_4_leka-283E1BE7BB5A4CDDBAAC04E599CF74B7.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictograms-3A9B0EB3A9CF4ABCB9B771B6047DF2D0/new_activities/recognition_emotions_pictograms_4_leka-283E1BE7BB5A4CDDBAAC04E599CF74B7.new_activity.yml
@@ -21,6 +21,9 @@ tags:
   - leka_pictograms
   - emotions
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_1_hortense-418F229DD3384711BB241CC5E4F07C46.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_1_hortense-418F229DD3384711BB241CC5E4F07C46.new_activity.yml
@@ -21,6 +21,9 @@ tags:
   - emotions
   - hortense
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_1_hugo-2046B91706984344AC8CDA8F3E630FE0.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_1_hugo-2046B91706984344AC8CDA8F3E630FE0.new_activity.yml
@@ -21,6 +21,9 @@ tags:
   - emotions
   - hugo
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_1_ladislas-5E7A2E95822643CEBB8628FA26AA0878.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_1_ladislas-5E7A2E95822643CEBB8628FA26AA0878.new_activity.yml
@@ -21,6 +21,9 @@ tags:
   - emotions
   - ladislas
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_1_lucie-69EB05CA4EA841F18D872FD406E81EC5.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_1_lucie-69EB05CA4EA841F18D872FD406E81EC5.new_activity.yml
@@ -21,6 +21,9 @@ tags:
   - emotions
   - lucie
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_1_yann-EA954F037A944DE292CDB070ECC22357.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_1_yann-EA954F037A944DE292CDB070ECC22357.new_activity.yml
@@ -21,6 +21,9 @@ tags:
   - emotions
   - yann
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_2_hortense-76C35A0EF85E48BCAF94CCBB83F8EDAF.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_2_hortense-76C35A0EF85E48BCAF94CCBB83F8EDAF.new_activity.yml
@@ -21,6 +21,9 @@ tags:
   - emotions
   - hortense
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_2_hortense_lucie-711FC9741264476AA295C8D800D16117.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_2_hortense_lucie-711FC9741264476AA295C8D800D16117.new_activity.yml
@@ -22,6 +22,9 @@ tags:
   - hortense
   - lucie
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_2_hortense_yann-C42F409C815043C39B45291B98CE375B.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_2_hortense_yann-C42F409C815043C39B45291B98CE375B.new_activity.yml
@@ -22,6 +22,9 @@ tags:
   - hortense
   - yann
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_2_hugo-CF8EDAED29B145C083540CBB993B9599.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_2_hugo-CF8EDAED29B145C083540CBB993B9599.new_activity.yml
@@ -21,6 +21,9 @@ tags:
   - emotions
   - hugo
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_2_hugo_ladislas-4B00611DE88D43A6B8FE057D9B09782A.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_2_hugo_ladislas-4B00611DE88D43A6B8FE057D9B09782A.new_activity.yml
@@ -21,6 +21,9 @@ tags:
   - emotions
   - ladislas
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_2_hugo_yann-098E1E5293E9483C98EC96EE746C02F8.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_2_hugo_yann-098E1E5293E9483C98EC96EE746C02F8.new_activity.yml
@@ -22,6 +22,9 @@ tags:
   - hugo
   - yann
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_2_ladislas-B41A5074B87245CEA2F826B31E6B2C3F.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_2_ladislas-B41A5074B87245CEA2F826B31E6B2C3F.new_activity.yml
@@ -21,6 +21,9 @@ tags:
   - emotions
   - ladislas
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_2_ladislas_lucie-46B40FAFE4AD435785F0A5489A931812.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_2_ladislas_lucie-46B40FAFE4AD435785F0A5489A931812.new_activity.yml
@@ -22,6 +22,9 @@ tags:
   - lucie
   - ladislas
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_2_lucie-CB8A88D070664156BDFC5F965BEBE3FE.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_2_lucie-CB8A88D070664156BDFC5F965BEBE3FE.new_activity.yml
@@ -21,6 +21,9 @@ tags:
   - emotions
   - lucie
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_2_yann-17EAB8CA31E84B5AACAA1A0DA9645B27.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_2_yann-17EAB8CA31E84B5AACAA1A0DA9645B27.new_activity.yml
@@ -21,6 +21,9 @@ tags:
   - emotions
   - yann
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_4_hortense-56FF7BE1A07B4913BBADD72186E5FAAA.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_4_hortense-56FF7BE1A07B4913BBADD72186E5FAAA.new_activity.yml
@@ -22,6 +22,9 @@ tags:
   - pictures
   - hortense
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_4_hortense_lucie-F7ADA37ED2154E01971E8CBD581DEFA9.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_4_hortense_lucie-F7ADA37ED2154E01971E8CBD581DEFA9.new_activity.yml
@@ -22,6 +22,9 @@ tags:
   - hortense
   - lucie
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_4_hortense_yann-45AAFF88B4C04125AD060257843936C6.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_4_hortense_yann-45AAFF88B4C04125AD060257843936C6.new_activity.yml
@@ -23,6 +23,9 @@ tags:
   - hortense
   - yann
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_4_hortense_yann_hugo_ladislas_lucie-DCCB05E61EDA4CB9B7A917E5C8C8EBC7.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_4_hortense_yann_hugo_ladislas_lucie-DCCB05E61EDA4CB9B7A917E5C8C8EBC7.new_activity.yml
@@ -25,6 +25,9 @@ tags:
   - lucie
   - hugo
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_4_hugo-EE32417A034346AFACF984F506774BFD.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_4_hugo-EE32417A034346AFACF984F506774BFD.new_activity.yml
@@ -22,6 +22,9 @@ tags:
   - pictures
   - hugo
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_4_hugo_ladislas-971B4219E3FC4A48847F3AF81CC71DC5.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_4_hugo_ladislas-971B4219E3FC4A48847F3AF81CC71DC5.new_activity.yml
@@ -23,6 +23,9 @@ tags:
   - hugo
   - ladislas
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_4_hugo_yann-693C02F1EF354C9C9152A4D386C04984.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_4_hugo_yann-693C02F1EF354C9C9152A4D386C04984.new_activity.yml
@@ -23,6 +23,9 @@ tags:
   - hugo
   - yann
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_4_ladislas-E71DD6285FB84AFEA1DCD7DF434F6B34.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_4_ladislas-E71DD6285FB84AFEA1DCD7DF434F6B34.new_activity.yml
@@ -22,6 +22,9 @@ tags:
   - pictures
   - ladislas
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_4_leka_team-542A920F76DD4F6C809C671C9AC3C7CF.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_4_leka_team-542A920F76DD4F6C809C671C9AC3C7CF.new_activity.yml
@@ -27,6 +27,9 @@ tags:
   - hugo
   - leka_team
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_4_lucie-9BC2D6BADB124D82B181DA6571B8E7BB.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_4_lucie-9BC2D6BADB124D82B181DA6571B8E7BB.new_activity.yml
@@ -22,6 +22,9 @@ tags:
   - pictures
   - lucie
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_4_yann-D4FAA879BD224C80B6DF122A68FE9E83.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_pictures-BA3CB88A6A6E49CB9AB83FA992BF852B/new_activities/recognition_emotions_pictures_4_yann-D4FAA879BD224C80B6DF122A68FE9E83.new_activity.yml
@@ -22,6 +22,9 @@ tags:
   - pictures
   - yann
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_robot-B63B1180ECAF46269402C0AD2F20191A/new_activities/recognition_emotions_robot_generalization_3-44C50975B50443D6A8C59207095CACE6.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_robot-B63B1180ECAF46269402C0AD2F20191A/new_activities/recognition_emotions_robot_generalization_3-44C50975B50443D6A8C59207095CACE6.new_activity.yml
@@ -25,6 +25,10 @@ tags:
   - leka_pictograms
   - emotions
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: robot
+
 hmi:
   - tablet_robot
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_robot-B63B1180ECAF46269402C0AD2F20191A/new_activities/recognition_emotions_robot_generalization_4-D1708A8981E749D6A1379B0CD984A6A7.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_robot-B63B1180ECAF46269402C0AD2F20191A/new_activities/recognition_emotions_robot_generalization_4-D1708A8981E749D6A1379B0CD984A6A7.new_activity.yml
@@ -25,6 +25,10 @@ tags:
   - leka_pictograms
   - emotions
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: robot
+
 hmi:
   - tablet_robot
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_robot-B63B1180ECAF46269402C0AD2F20191A/new_activities/recognition_emotions_robot_generalization_6-B223003D2D7E44E59A1E18DA59ACA7AD.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_robot-B63B1180ECAF46269402C0AD2F20191A/new_activities/recognition_emotions_robot_generalization_6-B223003D2D7E44E59A1E18DA59ACA7AD.new_activity.yml
@@ -25,6 +25,10 @@ tags:
   - leka_pictograms
   - emotions
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: robot
+
 hmi:
   - tablet_robot
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_robot-B63B1180ECAF46269402C0AD2F20191A/new_activities/recognition_emotions_robot_image_1-1E39204F7D4A43179FA161CDC82B7C37.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_robot-B63B1180ECAF46269402C0AD2F20191A/new_activities/recognition_emotions_robot_image_1-1E39204F7D4A43179FA161CDC82B7C37.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - characters
   - emotions
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: robot
+
 hmi:
   - tablet_robot
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_robot-B63B1180ECAF46269402C0AD2F20191A/new_activities/recognition_emotions_robot_image_2-F7C2EBD557CC4AA8BD91A49B6816CB33.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_robot-B63B1180ECAF46269402C0AD2F20191A/new_activities/recognition_emotions_robot_image_2-F7C2EBD557CC4AA8BD91A49B6816CB33.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - characters
   - emotions
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: robot
+
 hmi:
   - tablet_robot
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_robot-B63B1180ECAF46269402C0AD2F20191A/new_activities/recognition_emotions_robot_image_4-2FAFEDDD82394FB89915A8C59CC69902.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_robot-B63B1180ECAF46269402C0AD2F20191A/new_activities/recognition_emotions_robot_image_4-2FAFEDDD82394FB89915A8C59CC69902.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - characters
   - emotions
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: robot
+
 hmi:
   - tablet_robot
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_robot-B63B1180ECAF46269402C0AD2F20191A/new_activities/recognition_emotions_robot_leka_1-DE8FD427EB8A4A828E1967C22748840A.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_robot-B63B1180ECAF46269402C0AD2F20191A/new_activities/recognition_emotions_robot_leka_1-DE8FD427EB8A4A828E1967C22748840A.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - leka_pictograms
   - emotions
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: robot
+
 hmi:
   - tablet_robot
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_robot-B63B1180ECAF46269402C0AD2F20191A/new_activities/recognition_emotions_robot_leka_2-A46A9406D8394C53B4218FDF228C93EF.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_robot-B63B1180ECAF46269402C0AD2F20191A/new_activities/recognition_emotions_robot_leka_2-A46A9406D8394C53B4218FDF228C93EF.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - leka_pictograms
   - emotions
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: robot
+
 hmi:
   - tablet_robot
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_robot-B63B1180ECAF46269402C0AD2F20191A/new_activities/recognition_emotions_robot_leka_4-1540481A25AD433FB390C3DA3793651C.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_robot-B63B1180ECAF46269402C0AD2F20191A/new_activities/recognition_emotions_robot_leka_4-1540481A25AD433FB390C3DA3793651C.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - leka_pictograms
   - emotions
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: robot
+
 hmi:
   - tablet_robot
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_robot-B63B1180ECAF46269402C0AD2F20191A/new_activities/recognition_emotions_robot_picture_1-22A6280EE77C4D3C8CB53E2A77075869.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_robot-B63B1180ECAF46269402C0AD2F20191A/new_activities/recognition_emotions_robot_picture_1-22A6280EE77C4D3C8CB53E2A77075869.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - pictures
   - emotions
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: robot
+
 hmi:
   - tablet_robot
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_robot-B63B1180ECAF46269402C0AD2F20191A/new_activities/recognition_emotions_robot_picture_2-922BB10EB26E4821BFBBF3372379D2D4.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_robot-B63B1180ECAF46269402C0AD2F20191A/new_activities/recognition_emotions_robot_picture_2-922BB10EB26E4821BFBBF3372379D2D4.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - pictures
   - emotions
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: robot
+
 hmi:
   - tablet_robot
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_robot-B63B1180ECAF46269402C0AD2F20191A/new_activities/recognition_emotions_robot_picture_4-C0F948C1A5154A548E028E6FF521E437.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_emotions_robot-B63B1180ECAF46269402C0AD2F20191A/new_activities/recognition_emotions_robot_picture_4-C0F948C1A5154A548E028E6FF521E437.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - pictures
   - emotions
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: robot
+
 hmi:
   - tablet_robot
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_family_members-AD1A9E2D874C47AEB3445D80E34DC702/new_activities/recognition_family_members_1-4B35157189D24260A943E8C510250460.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_family_members-AD1A9E2D874C47AEB3445D80E34DC702/new_activities/recognition_family_members_1-4B35157189D24260A943E8C510250460.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - family_members
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_family_members-AD1A9E2D874C47AEB3445D80E34DC702/new_activities/recognition_family_members_2-CD589A3DA58A4E738D37B8878F0BA107.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_family_members-AD1A9E2D874C47AEB3445D80E34DC702/new_activities/recognition_family_members_2-CD589A3DA58A4E738D37B8878F0BA107.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - family_members
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_family_members-AD1A9E2D874C47AEB3445D80E34DC702/new_activities/recognition_family_members_4-A7611096717E43938D51A7FED5A0EE4E.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_family_members-AD1A9E2D874C47AEB3445D80E34DC702/new_activities/recognition_family_members_4-A7611096717E43938D51A7FED5A0EE4E.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - family_members
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_family_members-AD1A9E2D874C47AEB3445D80E34DC702/new_activities/recognition_family_members_6-B8FA6D153A764A29811D5B606956CA44.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_family_members-AD1A9E2D874C47AEB3445D80E34DC702/new_activities/recognition_family_members_6-B8FA6D153A764A29811D5B606956CA44.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - family_members
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_garden_items-A1006027902E44C0B38BC3D3BAEDD4F6/new_activities/recognition_garden_items_1-34E696B157354C76B9613F4C7E185BEE.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_garden_items-A1006027902E44C0B38BC3D3BAEDD4F6/new_activities/recognition_garden_items_1-34E696B157354C76B9613F4C7E185BEE.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - home_objects
   - garden
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_garden_items-A1006027902E44C0B38BC3D3BAEDD4F6/new_activities/recognition_garden_items_2-479F70F09C9D4934844A0C0663B21648.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_garden_items-A1006027902E44C0B38BC3D3BAEDD4F6/new_activities/recognition_garden_items_2-479F70F09C9D4934844A0C0663B21648.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - home_objects
   - garden
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_garden_items-A1006027902E44C0B38BC3D3BAEDD4F6/new_activities/recognition_garden_items_4-54A1A7A32EFA4A858C5A1E6AD0D3DA48.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_garden_items-A1006027902E44C0B38BC3D3BAEDD4F6/new_activities/recognition_garden_items_4-54A1A7A32EFA4A858C5A1E6AD0D3DA48.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - home_objects
   - garden
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_garden_items-A1006027902E44C0B38BC3D3BAEDD4F6/new_activities/recognition_garden_items_6-B5BEA82CDC7743FD905D5DA788E90C28.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_garden_items-A1006027902E44C0B38BC3D3BAEDD4F6/new_activities/recognition_garden_items_6-B5BEA82CDC7743FD905D5DA788E90C28.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - home_objects
   - garden
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_halloween-DD01FCFF7BCB4A44A78BF7C813CE8DF5/new_activities/recognition_halloween_1-5E9C3E7866BC47E8931701F244459AF6.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_halloween-DD01FCFF7BCB4A44A78BF7C813CE8DF5/new_activities/recognition_halloween_1-5E9C3E7866BC47E8931701F244459AF6.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - autumn
   - festivities
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_halloween-DD01FCFF7BCB4A44A78BF7C813CE8DF5/new_activities/recognition_halloween_2-CDA535CD5EF442849E5C8E22E2B62914.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_halloween-DD01FCFF7BCB4A44A78BF7C813CE8DF5/new_activities/recognition_halloween_2-CDA535CD5EF442849E5C8E22E2B62914.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - autumn
   - festivities
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_halloween-DD01FCFF7BCB4A44A78BF7C813CE8DF5/new_activities/recognition_halloween_4-2F92E57BBA8F4869AC1693FE34B4F462.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_halloween-DD01FCFF7BCB4A44A78BF7C813CE8DF5/new_activities/recognition_halloween_4-2F92E57BBA8F4869AC1693FE34B4F462.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - autumn
   - festivities
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_kitchen_items-FCBEE55DD11F427785A12328E6E01C8E/new_activities/recognition_kitchen_items_household_appliances-2CBFAD17B01F4288AAE9CCCE37088FEC.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_kitchen_items-FCBEE55DD11F427785A12328E6E01C8E/new_activities/recognition_kitchen_items_household_appliances-2CBFAD17B01F4288AAE9CCCE37088FEC.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - everyday_objects
   - home_objects
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_kitchen_items-FCBEE55DD11F427785A12328E6E01C8E/new_activities/recognition_kitchen_items_kitchen_utensils-A9BC9B8ED47F4EA3A1760EFCCCBE0977.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_kitchen_items-FCBEE55DD11F427785A12328E6E01C8E/new_activities/recognition_kitchen_items_kitchen_utensils-A9BC9B8ED47F4EA3A1760EFCCCBE0977.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - everyday_objects
   - home_objects
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_kitchen_items-FCBEE55DD11F427785A12328E6E01C8E/new_activities/recognition_kitchen_items_tableware-6E87124002B34BC18520CDD94BFB8D07.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_kitchen_items-FCBEE55DD11F427785A12328E6E01C8E/new_activities/recognition_kitchen_items_tableware-6E87124002B34BC18520CDD94BFB8D07.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - everyday_objects
   - home_objects
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_modes_of_transportation-B20B0721C37644E9A0168481421893F8/new_activities/recognition_modes_of_transportation_1-0F5E9FE3202D4F5197F7C93B8945329C.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_modes_of_transportation-B20B0721C37644E9A0168481421893F8/new_activities/recognition_modes_of_transportation_1-0F5E9FE3202D4F5197F7C93B8945329C.new_activity.yml
@@ -20,6 +20,10 @@ skills:
 tags:
   - modes_of_transportation
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_modes_of_transportation-B20B0721C37644E9A0168481421893F8/new_activities/recognition_modes_of_transportation_2-4EE973F2856544A89352D123BDF8293D.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_modes_of_transportation-B20B0721C37644E9A0168481421893F8/new_activities/recognition_modes_of_transportation_2-4EE973F2856544A89352D123BDF8293D.new_activity.yml
@@ -20,6 +20,10 @@ skills:
 tags:
   - modes_of_transportation
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_modes_of_transportation-B20B0721C37644E9A0168481421893F8/new_activities/recognition_modes_of_transportation_4-B3A742E302F243DA9CA8D8F9AB1765FE.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_modes_of_transportation-B20B0721C37644E9A0168481421893F8/new_activities/recognition_modes_of_transportation_4-B3A742E302F243DA9CA8D8F9AB1765FE.new_activity.yml
@@ -20,6 +20,10 @@ skills:
 tags:
   - modes_of_transportation
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_modes_of_transportation-B20B0721C37644E9A0168481421893F8/new_activities/recognition_modes_of_transportation_6-AE79A7F21F764925848038007F2035C1.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_modes_of_transportation-B20B0721C37644E9A0168481421893F8/new_activities/recognition_modes_of_transportation_6-AE79A7F21F764925848038007F2035C1.new_activity.yml
@@ -20,6 +20,10 @@ skills:
 tags:
   - modes_of_transportation
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_professions-92ACC48ED3A041DE959EA5C2E8600441/new_activities/recognition_professions_drawings_1_image-F6BBB2161CFC4E3086C3D79DDED8C126.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_professions-92ACC48ED3A041DE959EA5C2E8600441/new_activities/recognition_professions_drawings_1_image-F6BBB2161CFC4E3086C3D79DDED8C126.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - professions
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_professions-92ACC48ED3A041DE959EA5C2E8600441/new_activities/recognition_professions_drawings_2_images-57D172F7E03C4910BE267A196B7E859A.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_professions-92ACC48ED3A041DE959EA5C2E8600441/new_activities/recognition_professions_drawings_2_images-57D172F7E03C4910BE267A196B7E859A.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - professions
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_professions-92ACC48ED3A041DE959EA5C2E8600441/new_activities/recognition_professions_drawings_3_images-A1151E7887214352ABB0B12A9861870A.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_professions-92ACC48ED3A041DE959EA5C2E8600441/new_activities/recognition_professions_drawings_3_images-A1151E7887214352ABB0B12A9861870A.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - professions
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_professions-92ACC48ED3A041DE959EA5C2E8600441/new_activities/recognition_professions_drawings_4_images-A85FAB3DE49B463789B02128571E5254.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_professions-92ACC48ED3A041DE959EA5C2E8600441/new_activities/recognition_professions_drawings_4_images-A85FAB3DE49B463789B02128571E5254.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - professions
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_professions-92ACC48ED3A041DE959EA5C2E8600441/new_activities/recognition_professions_drawings_5_images-AB8488E3C93F436E962BB84210F5BD03.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_professions-92ACC48ED3A041DE959EA5C2E8600441/new_activities/recognition_professions_drawings_5_images-AB8488E3C93F436E962BB84210F5BD03.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - professions
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_professions-92ACC48ED3A041DE959EA5C2E8600441/new_activities/recognition_professions_drawings_6_images-2563A47CEA904434811B7881F715F98A.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_professions-92ACC48ED3A041DE959EA5C2E8600441/new_activities/recognition_professions_drawings_6_images-2563A47CEA904434811B7881F715F98A.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - professions
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_seaside_holidays-B1BA5597BC594082AECE293AD25CFA89/new_activities/recognition_seaside_holidays_1-E8B904158A0D48E785C398FEEB51F007.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_seaside_holidays-B1BA5597BC594082AECE293AD25CFA89/new_activities/recognition_seaside_holidays_1-E8B904158A0D48E785C398FEEB51F007.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - holidays
   - sea
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_seaside_holidays-B1BA5597BC594082AECE293AD25CFA89/new_activities/recognition_seaside_holidays_2-9C76872851904E75B323FDF5EF2DCFDF.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_seaside_holidays-B1BA5597BC594082AECE293AD25CFA89/new_activities/recognition_seaside_holidays_2-9C76872851904E75B323FDF5EF2DCFDF.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - holidays
   - sea
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_seaside_holidays-B1BA5597BC594082AECE293AD25CFA89/new_activities/recognition_seaside_holidays_3-29A6278A44B941DEA1DFE929640A04C8.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_seaside_holidays-B1BA5597BC594082AECE293AD25CFA89/new_activities/recognition_seaside_holidays_3-29A6278A44B941DEA1DFE929640A04C8.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - holidays
   - sea
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_seaside_holidays-B1BA5597BC594082AECE293AD25CFA89/new_activities/recognition_seaside_holidays_4-D0D6AB694E4D4984895A1887B4C4957C.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_seaside_holidays-B1BA5597BC594082AECE293AD25CFA89/new_activities/recognition_seaside_holidays_4-D0D6AB694E4D4984895A1887B4C4957C.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - holidays
   - sea
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_seaside_holidays-B1BA5597BC594082AECE293AD25CFA89/new_activities/recognition_seaside_holidays_5-D99071D8358B48668CD1AB55FDA9A2F8.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_seaside_holidays-B1BA5597BC594082AECE293AD25CFA89/new_activities/recognition_seaside_holidays_5-D99071D8358B48668CD1AB55FDA9A2F8.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - holidays
   - sea
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_seaside_holidays-B1BA5597BC594082AECE293AD25CFA89/new_activities/recognition_seaside_holidays_6-4D2170812B8541F481CF1D45FD17BFD7.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_seaside_holidays-B1BA5597BC594082AECE293AD25CFA89/new_activities/recognition_seaside_holidays_6-4D2170812B8541F481CF1D45FD17BFD7.new_activity.yml
@@ -22,6 +22,10 @@ tags:
   - holidays
   - sea
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_animals-FED25D9B424E42019F03593FE0D65AEE/new_activities/recognition_sounds_animals_drawings_1_image-C4CBE259AC1347DE9C7EBE642EA9BA35.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_animals-FED25D9B424E42019F03593FE0D65AEE/new_activities/recognition_sounds_animals_drawings_1_image-C4CBE259AC1347DE9C7EBE642EA9BA35.new_activity.yml
@@ -25,6 +25,10 @@ tags:
   - animals
   - listening
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_animals-FED25D9B424E42019F03593FE0D65AEE/new_activities/recognition_sounds_animals_drawings_2_images-9D3DE26C58034D9AA9301EF0FBBD6761.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_animals-FED25D9B424E42019F03593FE0D65AEE/new_activities/recognition_sounds_animals_drawings_2_images-9D3DE26C58034D9AA9301EF0FBBD6761.new_activity.yml
@@ -25,6 +25,10 @@ tags:
   - animals
   - listening
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_animals-FED25D9B424E42019F03593FE0D65AEE/new_activities/recognition_sounds_animals_drawings_3_images-77EE54847AEC4BD3BAE7D1288342AAD6.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_animals-FED25D9B424E42019F03593FE0D65AEE/new_activities/recognition_sounds_animals_drawings_3_images-77EE54847AEC4BD3BAE7D1288342AAD6.new_activity.yml
@@ -25,6 +25,10 @@ tags:
   - animals
   - listening
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_animals-FED25D9B424E42019F03593FE0D65AEE/new_activities/recognition_sounds_animals_drawings_4_images-B60142FDD7DE4E9FBBA7E9E9BF1ECF08.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_animals-FED25D9B424E42019F03593FE0D65AEE/new_activities/recognition_sounds_animals_drawings_4_images-B60142FDD7DE4E9FBBA7E9E9BF1ECF08.new_activity.yml
@@ -25,6 +25,10 @@ tags:
   - animals
   - listening
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_animals-FED25D9B424E42019F03593FE0D65AEE/new_activities/recognition_sounds_animals_drawings_5_images-B8CCEFBDAFFF4A18A5BAA95335141C02.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_animals-FED25D9B424E42019F03593FE0D65AEE/new_activities/recognition_sounds_animals_drawings_5_images-B8CCEFBDAFFF4A18A5BAA95335141C02.new_activity.yml
@@ -25,6 +25,10 @@ tags:
   - animals
   - listening
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_animals-FED25D9B424E42019F03593FE0D65AEE/new_activities/recognition_sounds_animals_drawings_6_images-75B58F8E595F431399E0BAB7278A860D.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_animals-FED25D9B424E42019F03593FE0D65AEE/new_activities/recognition_sounds_animals_drawings_6_images-75B58F8E595F431399E0BAB7278A860D.new_activity.yml
@@ -25,6 +25,10 @@ tags:
   - animals
   - listening
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_emotions-2D48CCB418BF4808BCB16148C901C617/new_activities/recognition_sounds_emotions_pictures_1_hortense-7AC45BEF2A2A45E7920C7333C7E88CD6.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_emotions-2D48CCB418BF4808BCB16148C901C617/new_activities/recognition_sounds_emotions_pictures_1_hortense-7AC45BEF2A2A45E7920C7333C7E88CD6.new_activity.yml
@@ -25,6 +25,10 @@ skills:
 tags:
   - hortense
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_emotions-2D48CCB418BF4808BCB16148C901C617/new_activities/recognition_sounds_emotions_pictures_1_ladislas-5F842C24C9474BF19333975561DE65E7.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_emotions-2D48CCB418BF4808BCB16148C901C617/new_activities/recognition_sounds_emotions_pictures_1_ladislas-5F842C24C9474BF19333975561DE65E7.new_activity.yml
@@ -25,6 +25,10 @@ skills:
 tags:
   - ladislas
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_emotions-2D48CCB418BF4808BCB16148C901C617/new_activities/recognition_sounds_emotions_pictures_1_lucie-60694D53CB2947AB9D9904587D82FDB3.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_emotions-2D48CCB418BF4808BCB16148C901C617/new_activities/recognition_sounds_emotions_pictures_1_lucie-60694D53CB2947AB9D9904587D82FDB3.new_activity.yml
@@ -25,6 +25,10 @@ skills:
 tags:
   - lucie
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_emotions-2D48CCB418BF4808BCB16148C901C617/new_activities/recognition_sounds_emotions_pictures_2_hortense-36FE0BCA63D844C4B1137B08784D1B8E.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_emotions-2D48CCB418BF4808BCB16148C901C617/new_activities/recognition_sounds_emotions_pictures_2_hortense-36FE0BCA63D844C4B1137B08784D1B8E.new_activity.yml
@@ -25,6 +25,10 @@ skills:
 tags:
   - hortense
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_emotions-2D48CCB418BF4808BCB16148C901C617/new_activities/recognition_sounds_emotions_pictures_2_hortense_ladislas-690BE86C58004D938F4F48C720E8C011.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_emotions-2D48CCB418BF4808BCB16148C901C617/new_activities/recognition_sounds_emotions_pictures_2_hortense_ladislas-690BE86C58004D938F4F48C720E8C011.new_activity.yml
@@ -26,6 +26,10 @@ tags:
   - hortense
   - ladislas
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_emotions-2D48CCB418BF4808BCB16148C901C617/new_activities/recognition_sounds_emotions_pictures_2_hortense_lucie-84464C54E42243FE8EA3B246CCA97064.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_emotions-2D48CCB418BF4808BCB16148C901C617/new_activities/recognition_sounds_emotions_pictures_2_hortense_lucie-84464C54E42243FE8EA3B246CCA97064.new_activity.yml
@@ -26,6 +26,10 @@ tags:
   - lucie
   - hortense
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_emotions-2D48CCB418BF4808BCB16148C901C617/new_activities/recognition_sounds_emotions_pictures_2_ladislas-65BE6D6886A44B15B30F035819990884.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_emotions-2D48CCB418BF4808BCB16148C901C617/new_activities/recognition_sounds_emotions_pictures_2_ladislas-65BE6D6886A44B15B30F035819990884.new_activity.yml
@@ -25,6 +25,10 @@ skills:
 tags:
   - ladislas
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_emotions-2D48CCB418BF4808BCB16148C901C617/new_activities/recognition_sounds_emotions_pictures_2_ladislas_lucie-A9F2CF9ADC744E02BE09B953E06DCAF8.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_emotions-2D48CCB418BF4808BCB16148C901C617/new_activities/recognition_sounds_emotions_pictures_2_ladislas_lucie-A9F2CF9ADC744E02BE09B953E06DCAF8.new_activity.yml
@@ -26,6 +26,10 @@ tags:
   - lucie
   - ladislas
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_emotions-2D48CCB418BF4808BCB16148C901C617/new_activities/recognition_sounds_emotions_pictures_2_lucie-A14D8CA364ED4A078AFD645C0BDE3B19.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_emotions-2D48CCB418BF4808BCB16148C901C617/new_activities/recognition_sounds_emotions_pictures_2_lucie-A14D8CA364ED4A078AFD645C0BDE3B19.new_activity.yml
@@ -25,6 +25,10 @@ skills:
 tags:
   - lucie
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_emotions-2D48CCB418BF4808BCB16148C901C617/new_activities/recognition_sounds_emotions_pictures_3_lucie_ladislas_hortense-59B0DE4C8A1C41DCA097DC451588AB7C.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_emotions-2D48CCB418BF4808BCB16148C901C617/new_activities/recognition_sounds_emotions_pictures_3_lucie_ladislas_hortense-59B0DE4C8A1C41DCA097DC451588AB7C.new_activity.yml
@@ -27,6 +27,10 @@ tags:
   - hortense
   - ladislas
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_emotions-2D48CCB418BF4808BCB16148C901C617/new_activities/recognition_sounds_emotions_pictures_4_hortense-C6ED67057F714AD1A4537072F4886B67.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_emotions-2D48CCB418BF4808BCB16148C901C617/new_activities/recognition_sounds_emotions_pictures_4_hortense-C6ED67057F714AD1A4537072F4886B67.new_activity.yml
@@ -25,6 +25,10 @@ skills:
 tags:
   - hortense
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_emotions-2D48CCB418BF4808BCB16148C901C617/new_activities/recognition_sounds_emotions_pictures_4_hortense_ladislas-893B8311014B419FA5B70D2466C8DA81.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_emotions-2D48CCB418BF4808BCB16148C901C617/new_activities/recognition_sounds_emotions_pictures_4_hortense_ladislas-893B8311014B419FA5B70D2466C8DA81.new_activity.yml
@@ -26,6 +26,10 @@ tags:
   - hortense
   - ladislas
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_emotions-2D48CCB418BF4808BCB16148C901C617/new_activities/recognition_sounds_emotions_pictures_4_hortense_lucie-52A21A68D36342CB95CF0AE709523471.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_emotions-2D48CCB418BF4808BCB16148C901C617/new_activities/recognition_sounds_emotions_pictures_4_hortense_lucie-52A21A68D36342CB95CF0AE709523471.new_activity.yml
@@ -26,6 +26,10 @@ tags:
   - lucie
   - hortense
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_emotions-2D48CCB418BF4808BCB16148C901C617/new_activities/recognition_sounds_emotions_pictures_4_ladislas-A486DB1DAA344DCDA614952F0C174CDA.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_emotions-2D48CCB418BF4808BCB16148C901C617/new_activities/recognition_sounds_emotions_pictures_4_ladislas-A486DB1DAA344DCDA614952F0C174CDA.new_activity.yml
@@ -25,6 +25,10 @@ skills:
 tags:
   - ladislas
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_emotions-2D48CCB418BF4808BCB16148C901C617/new_activities/recognition_sounds_emotions_pictures_4_ladislas_lucie-9800B2088C4B4A888FD5BE833D72414B.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_emotions-2D48CCB418BF4808BCB16148C901C617/new_activities/recognition_sounds_emotions_pictures_4_ladislas_lucie-9800B2088C4B4A888FD5BE833D72414B.new_activity.yml
@@ -26,6 +26,10 @@ tags:
   - lucie
   - ladislas
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_emotions-2D48CCB418BF4808BCB16148C901C617/new_activities/recognition_sounds_emotions_pictures_4_lucie-57F83636D7314053A8B734E2D616C057.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_emotions-2D48CCB418BF4808BCB16148C901C617/new_activities/recognition_sounds_emotions_pictures_4_lucie-57F83636D7314053A8B734E2D616C057.new_activity.yml
@@ -25,6 +25,10 @@ skills:
 tags:
   - lucie
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_musical_instruments-6A5EF209D00942F4AEEA4AEC6DAC052A/new_activities/recognition_sounds_musical_instruments_drawings_1_image-FA8702A14D4E4792AEFB6158115C1AAD.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_musical_instruments-6A5EF209D00942F4AEEA4AEC6DAC052A/new_activities/recognition_sounds_musical_instruments_drawings_1_image-FA8702A14D4E4792AEFB6158115C1AAD.new_activity.yml
@@ -26,6 +26,10 @@ tags:
   - music
   - listening
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_musical_instruments-6A5EF209D00942F4AEEA4AEC6DAC052A/new_activities/recognition_sounds_musical_instruments_drawings_2_images-1032EA5E0C3D421F8AC806CAA8897D97.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_musical_instruments-6A5EF209D00942F4AEEA4AEC6DAC052A/new_activities/recognition_sounds_musical_instruments_drawings_2_images-1032EA5E0C3D421F8AC806CAA8897D97.new_activity.yml
@@ -26,6 +26,10 @@ tags:
   - music
   - listening
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_musical_instruments-6A5EF209D00942F4AEEA4AEC6DAC052A/new_activities/recognition_sounds_musical_instruments_drawings_3_images-BA0F2146BD5A420095F82A4C859D0EE8.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_musical_instruments-6A5EF209D00942F4AEEA4AEC6DAC052A/new_activities/recognition_sounds_musical_instruments_drawings_3_images-BA0F2146BD5A420095F82A4C859D0EE8.new_activity.yml
@@ -26,6 +26,10 @@ tags:
   - music
   - listening
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_musical_instruments-6A5EF209D00942F4AEEA4AEC6DAC052A/new_activities/recognition_sounds_musical_instruments_drawings_4_images-6259DA1AAB6E4273B684904D4312FB70.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_musical_instruments-6A5EF209D00942F4AEEA4AEC6DAC052A/new_activities/recognition_sounds_musical_instruments_drawings_4_images-6259DA1AAB6E4273B684904D4312FB70.new_activity.yml
@@ -26,6 +26,10 @@ tags:
   - music
   - listening
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_musical_instruments-6A5EF209D00942F4AEEA4AEC6DAC052A/new_activities/recognition_sounds_musical_instruments_drawings_5_images-94C14E6AA18E4FCA995B00B91103FA79.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_musical_instruments-6A5EF209D00942F4AEEA4AEC6DAC052A/new_activities/recognition_sounds_musical_instruments_drawings_5_images-94C14E6AA18E4FCA995B00B91103FA79.new_activity.yml
@@ -26,6 +26,10 @@ tags:
   - music
   - listening
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_musical_instruments-6A5EF209D00942F4AEEA4AEC6DAC052A/new_activities/recognition_sounds_musical_instruments_drawings_6_images-B691334EF5A743EDAFCFC0701377D84E.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sounds_musical_instruments-6A5EF209D00942F4AEEA4AEC6DAC052A/new_activities/recognition_sounds_musical_instruments_drawings_6_images-B691334EF5A743EDAFCFC0701377D84E.new_activity.yml
@@ -26,6 +26,10 @@ tags:
   - music
   - listening
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sports-C7F3963541234712A2701C0EB9E2EEAE/new_activities/recognition_sports_drawings_1_image-69283AFFE9F24D73A99F22F46D9D28D3.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sports-C7F3963541234712A2701C0EB9E2EEAE/new_activities/recognition_sports_drawings_1_image-69283AFFE9F24D73A99F22F46D9D28D3.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - sports
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sports-C7F3963541234712A2701C0EB9E2EEAE/new_activities/recognition_sports_drawings_2_images-DF4A9657809D4435916A82A8314D2E4A.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sports-C7F3963541234712A2701C0EB9E2EEAE/new_activities/recognition_sports_drawings_2_images-DF4A9657809D4435916A82A8314D2E4A.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - sports
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sports-C7F3963541234712A2701C0EB9E2EEAE/new_activities/recognition_sports_drawings_3_images-2AFAF1C1D3ED4602A9BBB8B06E51D59D.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sports-C7F3963541234712A2701C0EB9E2EEAE/new_activities/recognition_sports_drawings_3_images-2AFAF1C1D3ED4602A9BBB8B06E51D59D.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - sports
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sports-C7F3963541234712A2701C0EB9E2EEAE/new_activities/recognition_sports_drawings_4_images-55ECB1EFFAA3466CA1704BCFE7AC371E.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sports-C7F3963541234712A2701C0EB9E2EEAE/new_activities/recognition_sports_drawings_4_images-55ECB1EFFAA3466CA1704BCFE7AC371E.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - sports
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sports-C7F3963541234712A2701C0EB9E2EEAE/new_activities/recognition_sports_drawings_5_images-659278115279467190B097830E94F250.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sports-C7F3963541234712A2701C0EB9E2EEAE/new_activities/recognition_sports_drawings_5_images-659278115279467190B097830E94F250.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - sports
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sports-C7F3963541234712A2701C0EB9E2EEAE/new_activities/recognition_sports_drawings_6_images-D9A7EC7FDFA5478596A36015A03F4D5E.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_sports-C7F3963541234712A2701C0EB9E2EEAE/new_activities/recognition_sports_drawings_6_images-D9A7EC7FDFA5478596A36015A03F4D5E.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - sports
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_the_ice_floe-0EAFF8A46A4C4D60A320EBBBF2CC03B8/new_activities/recognition_the_ice_floe_1-8D8DDB52F3FD41169688C2811CCD2D66.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_the_ice_floe-0EAFF8A46A4C4D60A320EBBBF2CC03B8/new_activities/recognition_the_ice_floe_1-8D8DDB52F3FD41169688C2811CCD2D66.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_the_ice_floe-0EAFF8A46A4C4D60A320EBBBF2CC03B8/new_activities/recognition_the_ice_floe_2-F8CFCF9AF97045B9B162F7889199E47A.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_the_ice_floe-0EAFF8A46A4C4D60A320EBBBF2CC03B8/new_activities/recognition_the_ice_floe_2-F8CFCF9AF97045B9B162F7889199E47A.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_the_ice_floe-0EAFF8A46A4C4D60A320EBBBF2CC03B8/new_activities/recognition_the_ice_floe_4-54CFAAB5FFAA43D4BFE48BA3F788AC8D.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_the_ice_floe-0EAFF8A46A4C4D60A320EBBBF2CC03B8/new_activities/recognition_the_ice_floe_4-54CFAAB5FFAA43D4BFE48BA3F788AC8D.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - animals
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_weather_and_time-1D8E1AB667DB40B199479D731EF96F2E.curriculum/new_activities/recognition_weather_and_time_day_night-7710D57FB7214D4F90246463F20773D1.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_weather_and_time-1D8E1AB667DB40B199479D731EF96F2E.curriculum/new_activities/recognition_weather_and_time_day_night-7710D57FB7214D4F90246463F20773D1.new_activity.yml
@@ -21,6 +21,10 @@ skills:
 tags:
   - weather_elements
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_weather_and_time-1D8E1AB667DB40B199479D731EF96F2E.curriculum/new_activities/recognition_weather_and_time_hot_and_cold-18DA1F9028CF447E819507B0A6562F2E.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_weather_and_time-1D8E1AB667DB40B199479D731EF96F2E.curriculum/new_activities/recognition_weather_and_time_hot_and_cold-18DA1F9028CF447E819507B0A6562F2E.new_activity.yml
@@ -23,6 +23,10 @@ tags:
   - hot
   - cold
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_weather_and_time-1D8E1AB667DB40B199479D731EF96F2E.curriculum/new_activities/recognition_weather_and_time_meteo_2_images-900AB87351824FACB2E289F426056034.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_weather_and_time-1D8E1AB667DB40B199479D731EF96F2E.curriculum/new_activities/recognition_weather_and_time_meteo_2_images-900AB87351824FACB2E289F426056034.new_activity.yml
@@ -21,6 +21,10 @@ tags:
   - weather_elements
   - seasons
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_weather_and_time-1D8E1AB667DB40B199479D731EF96F2E.curriculum/new_activities/recognition_weather_and_time_meteo_4_images-030525AA798F4E0D8EDAFAF3939471F9.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_weather_and_time-1D8E1AB667DB40B199479D731EF96F2E.curriculum/new_activities/recognition_weather_and_time_meteo_4_images-030525AA798F4E0D8EDAFAF3939471F9.new_activity.yml
@@ -21,6 +21,10 @@ tags:
   - weather_elements
   - seasons
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_winter_holidays-2B8E01DABDBC4863A962B785D4069B3E/new_activities/recognition_winter_holidays_1-9C5A3D5EA2DC47A1905C013133AEF72C.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_winter_holidays-2B8E01DABDBC4863A962B785D4069B3E/new_activities/recognition_winter_holidays_1-9C5A3D5EA2DC47A1905C013133AEF72C.new_activity.yml
@@ -23,6 +23,10 @@ tags:
   - mountain
   - winter
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_winter_holidays-2B8E01DABDBC4863A962B785D4069B3E/new_activities/recognition_winter_holidays_2-55885C9A9EC94AC9A6955E2A8322BEAB.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_winter_holidays-2B8E01DABDBC4863A962B785D4069B3E/new_activities/recognition_winter_holidays_2-55885C9A9EC94AC9A6955E2A8322BEAB.new_activity.yml
@@ -23,6 +23,10 @@ tags:
   - mountain
   - winter
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_winter_holidays-2B8E01DABDBC4863A962B785D4069B3E/new_activities/recognition_winter_holidays_4-63E772D717F545699C9369FADA2A2CAB.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_winter_holidays-2B8E01DABDBC4863A962B785D4069B3E/new_activities/recognition_winter_holidays_4-63E772D717F545699C9369FADA2A2CAB.new_activity.yml
@@ -23,6 +23,10 @@ tags:
   - mountain
   - winter
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_winter_holidays-2B8E01DABDBC4863A962B785D4069B3E/new_activities/recognition_winter_holidays_6-A0C5C7FF52FA4FEA907ECB784D489A5F.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_recognition_winter_holidays-2B8E01DABDBC4863A962B785D4069B3E/new_activities/recognition_winter_holidays_6-A0C5C7FF52FA4FEA907ECB784D489A5F.new_activity.yml
@@ -23,6 +23,10 @@ tags:
   - mountain
   - winter
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: ear
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_sequencing_daily_life-FCAD78F080624326B00169811C4C5622/new_activities/sequencing_daily_life_dressing_up-A33F20A81F8F478E8B705F7FAB807965.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_sequencing_daily_life-FCAD78F080624326B00169811C4C5622/new_activities/sequencing_daily_life_dressing_up-A33F20A81F8F478E8B705F7FAB807965.new_activity.yml
@@ -22,6 +22,9 @@ skills:
 tags:
   - everyday_objects
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_sequencing_daily_life-FCAD78F080624326B00169811C4C5622/new_activities/sequencing_daily_life_hand_washing-5EC782D9173A4CD999450FC573DD652D.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_sequencing_daily_life-FCAD78F080624326B00169811C4C5622/new_activities/sequencing_daily_life_hand_washing-5EC782D9173A4CD999450FC573DD652D.new_activity.yml
@@ -22,6 +22,9 @@ skills:
 tags:
   - everyday_objects
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_sequencing_daily_life-FCAD78F080624326B00169811C4C5622/new_activities/sequencing_daily_life_toilets-8D126A04F37D4E8BA498EE4758E071AC.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_sequencing_daily_life-FCAD78F080624326B00169811C4C5622/new_activities/sequencing_daily_life_toilets-8D126A04F37D4E8BA498EE4758E071AC.new_activity.yml
@@ -22,6 +22,9 @@ skills:
 tags:
   - everyday_objects
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_sequencing_daily_life-FCAD78F080624326B00169811C4C5622/new_activities/sequencing_daily_life_tooth_brushing-0CFC700AF1FE476E9A934487A3159FBD.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_sequencing_daily_life-FCAD78F080624326B00169811C4C5622/new_activities/sequencing_daily_life_tooth_brushing-0CFC700AF1FE476E9A934487A3159FBD.new_activity.yml
@@ -22,6 +22,9 @@ skills:
 tags:
   - everyday_objects
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_shape_recognition-785607C27B1449A1B12F10302A754486/new_activities/shape_recognition_2_images-6C1B88C482F749E69BE121CA3181E268.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_shape_recognition-785607C27B1449A1B12F10302A754486/new_activities/shape_recognition_2_images-6C1B88C482F749E69BE121CA3181E268.new_activity.yml
@@ -20,6 +20,10 @@ skills:
 tags:
   - geometric_shapes
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_shape_recognition-785607C27B1449A1B12F10302A754486/new_activities/shape_recognition_4_images-28E85D51E1F441A29F38AA2F246ED67A.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_shape_recognition-785607C27B1449A1B12F10302A754486/new_activities/shape_recognition_4_images-28E85D51E1F441A29F38AA2F246ED67A.new_activity.yml
@@ -20,6 +20,10 @@ skills:
 tags:
   - geometric_shapes
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_shape_recognition-785607C27B1449A1B12F10302A754486/new_activities/shape_recognition_filled_and_unfilled_shapes_2_images-4CCA0C2662814FCE8B63979BF88472C1.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_shape_recognition-785607C27B1449A1B12F10302A754486/new_activities/shape_recognition_filled_and_unfilled_shapes_2_images-4CCA0C2662814FCE8B63979BF88472C1.new_activity.yml
@@ -20,6 +20,10 @@ skills:
 tags:
   - geometric_shapes
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_shape_recognition-785607C27B1449A1B12F10302A754486/new_activities/shape_recognition_filled_and_unfilled_shapes_4_images-CFA4165855C7429C9C806CD0A2E15A30.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_shape_recognition-785607C27B1449A1B12F10302A754486/new_activities/shape_recognition_filled_and_unfilled_shapes_4_images-CFA4165855C7429C9C806CD0A2E15A30.new_activity.yml
@@ -20,6 +20,10 @@ skills:
 tags:
   - geometric_shapes
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_shape_recognition-785607C27B1449A1B12F10302A754486/new_activities/shape_recognition_identical_shapes_and_colors_2_images-289E486B17D9441CBFCEB859B569F2BD.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_shape_recognition-785607C27B1449A1B12F10302A754486/new_activities/shape_recognition_identical_shapes_and_colors_2_images-289E486B17D9441CBFCEB859B569F2BD.new_activity.yml
@@ -21,6 +21,10 @@ tags:
   - geometric_shapes
   - colors
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_shape_recognition-785607C27B1449A1B12F10302A754486/new_activities/shape_recognition_identical_shapes_and_colors_4_images-605AB303F60C48708CDFF5991BF93F28.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_shape_recognition-785607C27B1449A1B12F10302A754486/new_activities/shape_recognition_identical_shapes_and_colors_4_images-605AB303F60C48708CDFF5991BF93F28.new_activity.yml
@@ -21,6 +21,10 @@ tags:
   - geometric_shapes
   - colors
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_sort_objects_by_location-CC406024F40C4834A66BB7C8F0E8C0AD/new_activities/sort_objects_by_location_1_zone_1_choice-03347E31BA8745E5A2A078F7F261CCB9.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_sort_objects_by_location-CC406024F40C4834A66BB7C8F0E8C0AD/new_activities/sort_objects_by_location_1_zone_1_choice-03347E31BA8745E5A2A078F7F261CCB9.new_activity.yml
@@ -21,6 +21,9 @@ skills:
 tags:
   - places
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_sort_objects_by_location-CC406024F40C4834A66BB7C8F0E8C0AD/new_activities/sort_objects_by_location_1_zone_2_choices-9F2C490657DF4A92B778445E35032032.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_sort_objects_by_location-CC406024F40C4834A66BB7C8F0E8C0AD/new_activities/sort_objects_by_location_1_zone_2_choices-9F2C490657DF4A92B778445E35032032.new_activity.yml
@@ -21,6 +21,9 @@ skills:
 tags:
   - places
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_sort_objects_by_location-CC406024F40C4834A66BB7C8F0E8C0AD/new_activities/sort_objects_by_location_1_zone_4_choices-F8B6AEB29BB845029537266BC18AA72C.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_sort_objects_by_location-CC406024F40C4834A66BB7C8F0E8C0AD/new_activities/sort_objects_by_location_1_zone_4_choices-F8B6AEB29BB845029537266BC18AA72C.new_activity.yml
@@ -21,6 +21,9 @@ skills:
 tags:
   - places
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_sort_objects_by_location-CC406024F40C4834A66BB7C8F0E8C0AD/new_activities/sort_objects_by_location_2_zones_2_choices-1990F5ED1FDE4A4BADC9EB273A32F614.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_sort_objects_by_location-CC406024F40C4834A66BB7C8F0E8C0AD/new_activities/sort_objects_by_location_2_zones_2_choices-1990F5ED1FDE4A4BADC9EB273A32F614.new_activity.yml
@@ -21,6 +21,9 @@ skills:
 tags:
   - places
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_sort_objects_by_location-CC406024F40C4834A66BB7C8F0E8C0AD/new_activities/sort_objects_by_location_2_zones_4_choices-6440FE2E15DD45D9B4B242541A5617F8.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_sort_objects_by_location-CC406024F40C4834A66BB7C8F0E8C0AD/new_activities/sort_objects_by_location_2_zones_4_choices-6440FE2E15DD45D9B4B242541A5617F8.new_activity.yml
@@ -21,6 +21,9 @@ skills:
 tags:
   - places
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_sort_objects_by_location-CC406024F40C4834A66BB7C8F0E8C0AD/new_activities/sort_objects_by_location_2_zones_6_choices-63091CA41C974376BBF7D4D51A7E63FA.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_sort_objects_by_location-CC406024F40C4834A66BB7C8F0E8C0AD/new_activities/sort_objects_by_location_2_zones_6_choices-63091CA41C974376BBF7D4D51A7E63FA.new_activity.yml
@@ -21,6 +21,9 @@ skills:
 tags:
   - places
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_sort_sweet_and_salty-5ED0AFBEC4504F6EBA52B26C65ED93CC/new_activities/sort_sweet_and_salty_1_zone_1_choice-FC67913DF57E4CA9896BDAA6EA3AC2F2.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_sort_sweet_and_salty-5ED0AFBEC4504F6EBA52B26C65ED93CC/new_activities/sort_sweet_and_salty_1_zone_1_choice-FC67913DF57E4CA9896BDAA6EA3AC2F2.new_activity.yml
@@ -21,6 +21,9 @@ skills:
 tags:
   - food
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_sort_sweet_and_salty-5ED0AFBEC4504F6EBA52B26C65ED93CC/new_activities/sort_sweet_and_salty_1_zone_2_choices-500B42D356C14D59AA2A77C9E1F1537A.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_sort_sweet_and_salty-5ED0AFBEC4504F6EBA52B26C65ED93CC/new_activities/sort_sweet_and_salty_1_zone_2_choices-500B42D356C14D59AA2A77C9E1F1537A.new_activity.yml
@@ -21,6 +21,9 @@ skills:
 tags:
   - food
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_sort_sweet_and_salty-5ED0AFBEC4504F6EBA52B26C65ED93CC/new_activities/sort_sweet_and_salty_2_zones_2_choices-A6325A93AF194ACAAF3744793E5EBD3D.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_sort_sweet_and_salty-5ED0AFBEC4504F6EBA52B26C65ED93CC/new_activities/sort_sweet_and_salty_2_zones_2_choices-A6325A93AF194ACAAF3744793E5EBD3D.new_activity.yml
@@ -21,6 +21,9 @@ skills:
 tags:
   - food
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_sort_sweet_and_salty-5ED0AFBEC4504F6EBA52B26C65ED93CC/new_activities/sort_sweet_and_salty_2_zones_4_choices-94EB65070737436AB76591B5FFE2BE92.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_sort_sweet_and_salty-5ED0AFBEC4504F6EBA52B26C65ED93CC/new_activities/sort_sweet_and_salty_2_zones_4_choices-94EB65070737436AB76591B5FFE2BE92.new_activity.yml
@@ -21,6 +21,9 @@ skills:
 tags:
   - food
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_visual_discrimination_shapes_and_colors-B142C14603F246C7B88C169E2CD3FF74/new_activities/visual_discrimination_colors_2_images-B19CECF4A26C4D6DA3AEB3627A45C75A.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_visual_discrimination_shapes_and_colors-B142C14603F246C7B88C169E2CD3FF74/new_activities/visual_discrimination_colors_2_images-B19CECF4A26C4D6DA3AEB3627A45C75A.new_activity.yml
@@ -21,6 +21,10 @@ tags:
   - geometric_shapes
   - colors
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_visual_discrimination_shapes_and_colors-B142C14603F246C7B88C169E2CD3FF74/new_activities/visual_discrimination_colors_4_images-98066E8FD536442EAB9DDF63A5C69F3C.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_visual_discrimination_shapes_and_colors-B142C14603F246C7B88C169E2CD3FF74/new_activities/visual_discrimination_colors_4_images-98066E8FD536442EAB9DDF63A5C69F3C.new_activity.yml
@@ -21,6 +21,10 @@ tags:
   - geometric_shapes
   - colors
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_visual_discrimination_shapes_and_colors-B142C14603F246C7B88C169E2CD3FF74/new_activities/visual_discrimination_shapes_2_images-3FE31D52276741E7AEA5E4CB59FD9A99.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_visual_discrimination_shapes_and_colors-B142C14603F246C7B88C169E2CD3FF74/new_activities/visual_discrimination_shapes_2_images-3FE31D52276741E7AEA5E4CB59FD9A99.new_activity.yml
@@ -21,6 +21,10 @@ tags:
   - geometric_shapes
   - colors
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_visual_discrimination_shapes_and_colors-B142C14603F246C7B88C169E2CD3FF74/new_activities/visual_discrimination_shapes_4_images-C5738371CFB94BB88F42B3040F758632.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_visual_discrimination_shapes_and_colors-B142C14603F246C7B88C169E2CD3FF74/new_activities/visual_discrimination_shapes_4_images-C5738371CFB94BB88F42B3040F758632.new_activity.yml
@@ -21,6 +21,10 @@ tags:
   - geometric_shapes
   - colors
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: eye
+
 hmi:
   - tablet
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/dnd_grid/dnd_grid_color.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/dnd_grid/dnd_grid_color.new_activity.yml
@@ -19,6 +19,9 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/dnd_grid/dnd_grid_emoji.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/dnd_grid/dnd_grid_emoji.new_activity.yml
@@ -19,6 +19,9 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/dnd_grid/dnd_grid_image.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/dnd_grid/dnd_grid_image.new_activity.yml
@@ -19,6 +19,9 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/dnd_grid/dnd_grid_sf_symbol.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/dnd_grid/dnd_grid_sf_symbol.new_activity.yml
@@ -19,6 +19,9 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/dnd_grid/dnd_grid_size.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/dnd_grid/dnd_grid_size.new_activity.yml
@@ -19,6 +19,10 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: drag_and_drop
+  - focus: mixed
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/dnd_grid_with_zones/dnd_with_zones_color.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/dnd_grid_with_zones/dnd_with_zones_color.new_activity.yml
@@ -19,6 +19,9 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/dnd_grid_with_zones/dnd_with_zones_emoji.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/dnd_grid_with_zones/dnd_with_zones_emoji.new_activity.yml
@@ -19,6 +19,9 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/dnd_grid_with_zones/dnd_with_zones_image.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/dnd_grid_with_zones/dnd_with_zones_image.new_activity.yml
@@ -19,6 +19,9 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/dnd_grid_with_zones/dnd_with_zones_sf_symbol.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/dnd_grid_with_zones/dnd_with_zones_sf_symbol.new_activity.yml
@@ -19,6 +19,9 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/dnd_grid_with_zones/dnd_with_zones_size.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/dnd_grid_with_zones/dnd_with_zones_size.new_activity.yml
@@ -19,6 +19,9 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: drag_and_drop
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/dnd_grid_with_zones/dnd_with_zones_size_listen.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/dnd_grid_with_zones/dnd_with_zones_size_listen.new_activity.yml
@@ -19,6 +19,10 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: drag_and_drop
+  - focus: ear
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/dnd_grid_with_zones/dnd_with_zones_size_observe.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/dnd_grid_with_zones/dnd_with_zones_size_observe.new_activity.yml
@@ -19,6 +19,10 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: drag_and_drop
+  - focus: eye
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/dnd_one_to_one/dnd_one_to_one_color.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/dnd_one_to_one/dnd_one_to_one_color.new_activity.yml
@@ -19,6 +19,10 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: drag_and_drop
+  - focus: mixed
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/dnd_one_to_one/dnd_one_to_one_emoji.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/dnd_one_to_one/dnd_one_to_one_emoji.new_activity.yml
@@ -19,6 +19,10 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: drag_and_drop
+  - focus: mixed
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/dnd_one_to_one/dnd_one_to_one_image.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/dnd_one_to_one/dnd_one_to_one_image.new_activity.yml
@@ -19,6 +19,10 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: drag_and_drop
+  - focus: mixed
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/dnd_one_to_one/dnd_one_to_one_sf_symbol.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/dnd_one_to_one/dnd_one_to_one_sf_symbol.new_activity.yml
@@ -19,6 +19,10 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: drag_and_drop
+  - focus: mixed
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/dnd_one_to_one/dnd_one_to_one_size.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/dnd_one_to_one/dnd_one_to_one_size.new_activity.yml
@@ -19,6 +19,10 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: drag_and_drop
+  - focus: mixed
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/gamepad/arrow_pad.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/gamepad/arrow_pad.new_activity.yml
@@ -19,6 +19,9 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/gamepad/arrow_pad_color_pad.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/gamepad/arrow_pad_color_pad.new_activity.yml
@@ -19,6 +19,9 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/gamepad/color_pad.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/gamepad/color_pad.new_activity.yml
@@ -19,6 +19,9 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/gamepad/joystick_pad_color_pad.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/gamepad/joystick_pad_color_pad.new_activity.yml
@@ -19,6 +19,9 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/magic_card/magic_card_size.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/magic_card/magic_card_size.new_activity.yml
@@ -19,6 +19,10 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: magic_card
+  - focus: mixed
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/memory/memory_color.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/memory/memory_color.new_activity.yml
@@ -19,6 +19,9 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/memory/memory_emoji.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/memory/memory_emoji.new_activity.yml
@@ -19,6 +19,9 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/memory/memory_image.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/memory/memory_image.new_activity.yml
@@ -19,6 +19,9 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/memory/memory_sf_symbol.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/memory/memory_sf_symbol.new_activity.yml
@@ -19,6 +19,9 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/memory/memory_size.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/memory/memory_size.new_activity.yml
@@ -19,6 +19,9 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/specialized/color_mediator.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/specialized/color_mediator.new_activity.yml
@@ -19,6 +19,9 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/specialized/color_music_pad.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/specialized/color_music_pad.new_activity.yml
@@ -19,6 +19,9 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/specialized/dance_freeze.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/specialized/dance_freeze.new_activity.yml
@@ -19,6 +19,9 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/specialized/discover_leka.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/specialized/discover_leka.new_activity.yml
@@ -19,6 +19,9 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/specialized/hide_and_seek.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/specialized/hide_and_seek.new_activity.yml
@@ -19,6 +19,9 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/specialized/melody.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/specialized/melody.new_activity.yml
@@ -19,6 +19,9 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/specialized/super_simon.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/specialized/super_simon.new_activity.yml
@@ -19,6 +19,9 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/specialized/xylophone.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/specialized/xylophone.new_activity.yml
@@ -19,6 +19,9 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: touch_to_select
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/tts/tts_color.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/tts/tts_color.new_activity.yml
@@ -19,6 +19,10 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: mixed
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/tts/tts_emoji.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/tts/tts_emoji.new_activity.yml
@@ -19,6 +19,10 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: mixed
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/tts/tts_image.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/tts/tts_image.new_activity.yml
@@ -19,6 +19,10 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: mixed
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/tts/tts_sf_symbol.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/tts/tts_sf_symbol.new_activity.yml
@@ -19,6 +19,10 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: mixed
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Resources/Content/newActivities/template/tts/tts_size.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/newActivities/template/tts/tts_size.new_activity.yml
@@ -19,6 +19,10 @@ skills:
 tags:
   - colors
 
+accessibility:
+  - gesture: touch_to_select
+  - focus: mixed
+
 hmi:
   - robot
 

--- a/Modules/ContentKit/Sources/Content/_NewSystem/Activity/Activity+Decodable.swift
+++ b/Modules/ContentKit/Sources/Content/_NewSystem/Activity/Activity+Decodable.swift
@@ -16,6 +16,7 @@ extension Activity: Decodable {
         case status
         case authors
         case skills
+        case accessibility
         case hmi
         case types
         case tags
@@ -38,6 +39,7 @@ extension Activity: Decodable {
         self.authors = authorIDs.compactMap { Authors.authors(id: $0) }
         let skillsIDs = try container.decode([String].self, forKey: .skills)
         self.skills = skillsIDs.compactMap { Skills.skill(id: $0) }
+        self.accessibility = try container.decodeIfPresent(Accessibility.self, forKey: .accessibility)
         let hmiIDs = try container.decode([String].self, forKey: .hmi)
         self.hmi = hmiIDs.compactMap { HMI.hmi(id: $0) }
         let typeIDs = try container.decode([String].self, forKey: .types)

--- a/Modules/ContentKit/Sources/Content/_NewSystem/Activity/Activity.swift
+++ b/Modules/ContentKit/Sources/Content/_NewSystem/Activity/Activity.swift
@@ -29,6 +29,7 @@ public struct Activity: Identifiable {
 
     public let authors: [Author]
     public let skills: [Skill]
+    public let accessibility: Accessibility?
     public let hmi: [HMIDetails]
     public let types: [ActivityType]
     public let tags: [Tag]

--- a/Modules/ContentKit/Sources/Content/_NewSystem/Models/Accessibility.swift
+++ b/Modules/ContentKit/Sources/Content/_NewSystem/Models/Accessibility.swift
@@ -1,0 +1,45 @@
+// Leka - iOS Monorepo
+// Copyright APF France handicap
+// SPDX-License-Identifier: Apache-2.0
+
+// MARK: Accessibility
+
+public struct Accessibility: Decodable {
+    // MARK: Lifecycle
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        self.focus = try container.decodeIfPresent(Focus.self, forKey: .focus)
+        self.gesture = try container.decodeIfPresent(Gesture.self, forKey: .gesture)
+    }
+
+    // MARK: Public
+
+    public enum Gesture: String, Decodable {
+        case dragAndDrop = "drag_and_drop"
+        case magicCard = "magic_card"
+        case touchToSelect = "touch_to_select"
+        case mixed
+    }
+
+    // swiftlint:disable identifier_name
+    public enum Focus: String, Decodable {
+        case ear
+        case eye
+        case robot
+        case mixed
+    }
+
+    // swiftlint:enable identifier_name
+
+    public let gesture: Gesture?
+    public let focus: Focus?
+
+    // MARK: Internal
+
+    enum CodingKeys: String, CodingKey {
+        case focus
+        case gesture
+    }
+}

--- a/Scripts/update_accessibility.py
+++ b/Scripts/update_accessibility.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Update accessibility metadata for activity YAML files."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable, Optional
+
+from ruamel.yaml import YAML
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CONTENT_ROOT = REPO_ROOT / "Modules" / "ContentKit" / "Resources" / "Content"
+
+DRAG_INTERFACES = {
+    "dragAndDropGrid",
+    "dragAndDropGridWithZones",
+    "dragAndDropOneToOne",
+}
+MAGIC_INTERFACES = {"magicCards"}
+
+EAR_TYPES = {"audio", "speech"}
+EYE_TYPES = {"color", "sfsymbol", "emoji", "image"}
+
+
+def iter_exercises(activity: dict) -> Iterable[dict]:
+    payload = activity.get("payload") or {}
+    for group_entry in payload.get("exercise_groups", []):
+        for exercise in group_entry.get("group", []):
+            if isinstance(exercise, dict):
+                yield exercise
+
+
+def gesture_from_interfaces(interfaces: Iterable[str]) -> Optional[str]:
+    categories = set()
+    for interface in interfaces:
+        if interface in DRAG_INTERFACES:
+            categories.add("drag_and_drop")
+        elif interface in MAGIC_INTERFACES:
+            categories.add("magic_card")
+        else:
+            categories.add("touch_to_select")
+    if not categories:
+        return None
+    if len(categories) == 1:
+        return next(iter(categories))
+    return "mixed"
+
+
+def focus_from_actions(actions: Iterable[dict]) -> Optional[str]:
+    categories = set()
+    for action in actions:
+        action_type = action.get("type")
+        if action_type == "robot":
+            categories.add("robot")
+            continue
+        if action_type != "ipad":
+            continue
+        value = action.get("value") or {}
+        value_type = value.get("type")
+        if value_type in EAR_TYPES:
+            categories.add("ear")
+        elif value_type in EYE_TYPES:
+            categories.add("eye")
+    if not categories:
+        return None
+    if len(categories) == 1:
+        return next(iter(categories))
+    return "mixed"
+
+
+def remove_existing_accessibility(lines: list[str]) -> None:
+    for index, line in enumerate(lines):
+        if line.strip() == "accessibility:":
+            start = index
+            end = index + 1
+            while end < len(lines) and (lines[end].startswith("  - ") or not lines[end].strip()):
+                end += 1
+            if start > 0 and not lines[start - 1].strip():
+                start -= 1
+            del lines[start:end]
+            break
+
+
+def insert_accessibility(lines: list[str], gesture: str, focus: Optional[str]) -> None:
+    try:
+        hmi_index = next(i for i, line in enumerate(lines) if line.strip() == "hmi:")
+    except StopIteration as exc:
+        raise ValueError("Could not find 'hmi:' key in activity file") from exc
+
+    insert_lines = ["accessibility:", f"  - gesture: {gesture}"]
+    if focus:
+        insert_lines.append(f"  - focus: {focus}")
+    insert_lines.append("")
+
+    if hmi_index > 0 and lines[hmi_index - 1].strip():
+        insert_lines.insert(0, "")
+
+    lines[hmi_index:hmi_index] = insert_lines
+
+
+def update_accessibility_text(text: str, gesture: Optional[str], focus: Optional[str]) -> str:
+    lines = text.splitlines()
+    had_trailing_newline = text.endswith("\n")
+
+    if not any(line.strip() == "hmi:" for line in lines):
+        return text
+
+    remove_existing_accessibility(lines)
+
+    if gesture:
+        insert_accessibility(lines, gesture, focus)
+
+    new_text = "\n".join(lines)
+    if had_trailing_newline or new_text:
+        new_text += "\n"
+    return new_text
+
+
+def update_accessibility(path: Path, yaml_loader: YAML) -> bool:
+    original_text = path.read_text(encoding="utf-8")
+    activity = yaml_loader.load(original_text)
+    if activity is None:
+        return False
+
+    interfaces: list[str] = []
+    actions: list[dict] = []
+    for exercise in iter_exercises(activity):
+        interface = exercise.get("interface")
+        if interface:
+            interfaces.append(interface)
+        action = exercise.get("action")
+        if isinstance(action, dict):
+            actions.append(action)
+
+    gesture = gesture_from_interfaces(interfaces)
+    focus = focus_from_actions(actions)
+
+    new_text = update_accessibility_text(original_text, gesture, focus)
+    if new_text == original_text:
+        return False
+
+    path.write_text(new_text, encoding="utf-8")
+    return True
+
+
+def main() -> None:
+    yaml_loader = YAML(typ="safe")
+
+    updated_files = []
+    for activity_path in sorted(CONTENT_ROOT.rglob("*.new_activity.yml")):
+        if update_accessibility(activity_path, yaml_loader):
+            updated_files.append(activity_path)
+
+    if updated_files:
+        print("Updated accessibility in", len(updated_files), "files")
+    else:
+        print("No accessibility updates were necessary.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Python utility that derives gesture and focus metadata from activity payloads
- populate all `*.new_activity.yml` files with the new `accessibility` block ahead of the `hmi` key

## Testing
- python Scripts/update_accessibility.py

------
https://chatgpt.com/codex/tasks/task_e_68e390de85688320b38d1ad362fb439c