### PR TITLE
ladislas/feature/ci upgrade actions clean up

### DIFF
--- a/.github/workflows/ci-fastlane-release_app_store.yml
+++ b/.github/workflows/ci-fastlane-release_app_store.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           lfs: true

--- a/.github/workflows/ci-fastlane-release_app_store.yml
+++ b/.github/workflows/ci-fastlane-release_app_store.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Set up mise
         uses: jdx/mise-action@v3
         with:
-          version: 2025.9.15
+          version: 2025.10.7
           install: true
           cache: true
 

--- a/.github/workflows/ci-fastlane-release_beta_internal.yml
+++ b/.github/workflows/ci-fastlane-release_beta_internal.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           lfs: true

--- a/.github/workflows/ci-fastlane-release_beta_internal.yml
+++ b/.github/workflows/ci-fastlane-release_beta_internal.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Set up mise
         uses: jdx/mise-action@v3
         with:
-          version: 2025.9.15
+          version: 2025.10.7
           install: true
           cache: true
 

--- a/.github/workflows/ci-linter-license_checker.yml
+++ b/.github/workflows/ci-linter-license_checker.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
           lfs: false

--- a/.github/workflows/ci-linter-pre_commit_hooks.yml
+++ b/.github/workflows/ci-linter-pre_commit_hooks.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up mise
         uses: jdx/mise-action@v3
         with:
-          version: 2025.9.15
+          version: 2025.10.7
           install: true
           cache: true
 

--- a/.github/workflows/ci-linter-pre_commit_hooks.yml
+++ b/.github/workflows/ci-linter-pre_commit_hooks.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 2
           lfs: true

--- a/.github/workflows/ci-linter-swiftformat.yml
+++ b/.github/workflows/ci-linter-swiftformat.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 2
           lfs: false

--- a/.github/workflows/ci-linter-swiftformat.yml
+++ b/.github/workflows/ci-linter-swiftformat.yml
@@ -31,14 +31,7 @@ jobs:
       - name: Set up mise
         uses: jdx/mise-action@v3
         with:
-          version: 2025.9.15
-          install: true
-          cache: true
-
-      - name: Setup mise
-        uses: jdx/mise-action@v3
-        with:
-          version: 2025.8.20
+          version: 2025.10.7
           install: true
           cache: true
 

--- a/.github/workflows/ci-linter-swiftlint.yml
+++ b/.github/workflows/ci-linter-swiftlint.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up mise
         uses: jdx/mise-action@v3
         with:
-          version: 2025.9.15
+          version: 2025.10.7
           install: true
           cache: true
 

--- a/.github/workflows/ci-linter-swiftlint.yml
+++ b/.github/workflows/ci-linter-swiftlint.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 2
           lfs: false

--- a/.github/workflows/ci-tuist-build-github_hosted.yml
+++ b/.github/workflows/ci-tuist-build-github_hosted.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           lfs: true

--- a/.github/workflows/ci-tuist-build-github_hosted.yml
+++ b/.github/workflows/ci-tuist-build-github_hosted.yml
@@ -29,7 +29,7 @@ env:
 jobs:
   build:
     name: build
-    runs-on: macos-15
+    runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci-tuist-build-github_hosted.yml
+++ b/.github/workflows/ci-tuist-build-github_hosted.yml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Config Xcode
         run: |
-          xcodes select 16.4
+          xcodes select 26.0.1
           defaults write com.apple.dt.XCBuild IgnoreFileSystemDeviceInodeChanges -bool YES
 
       - name: tuist install

--- a/.github/workflows/ci-tuist-build-github_hosted.yml
+++ b/.github/workflows/ci-tuist-build-github_hosted.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Setup mise
         uses: jdx/mise-action@v3
         with:
-          version: 2025.8.20
+          version: 2025.10.7
           install: true
           cache: true
 

--- a/.github/workflows/ci-tuist-build.yml
+++ b/.github/workflows/ci-tuist-build.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
           lfs: true

--- a/.github/workflows/ci-tuist-build.yml
+++ b/.github/workflows/ci-tuist-build.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Set up mise
         uses: jdx/mise-action@v3
         with:
-          version: 2025.9.15
+          version: 2025.10.7
           install: true
           cache: true
 

--- a/.github/workflows/ci-tuist-inspect.yml
+++ b/.github/workflows/ci-tuist-inspect.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Config Xcode
         run: |
-          xcodes select 16.4
+          xcodes select 26.0.1
           defaults write com.apple.dt.XCBuild IgnoreFileSystemDeviceInodeChanges -bool YES
 
       - name: tuist install

--- a/.github/workflows/ci-tuist-inspect.yml
+++ b/.github/workflows/ci-tuist-inspect.yml
@@ -30,7 +30,7 @@ env:
 jobs:
   inspect:
     name: inspect
-    runs-on: macos-15
+    runs-on: macos-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci-tuist-inspect.yml
+++ b/.github/workflows/ci-tuist-inspect.yml
@@ -39,10 +39,10 @@ jobs:
           fetch-depth: 1
           lfs: true
 
-      - name: Setup mise
+      - name: Set up mise
         uses: jdx/mise-action@v3
         with:
-          version: 2025.8.20
+          version: 2025.10.7
           install: true
           cache: true
 

--- a/.github/workflows/ci-tuist-inspect.yml
+++ b/.github/workflows/ci-tuist-inspect.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
           lfs: true

--- a/.github/workflows/ci-tuist-unit_tests.yml
+++ b/.github/workflows/ci-tuist-unit_tests.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set up mise
         uses: jdx/mise-action@v3
         with:
-          version: 2025.9.15
+          version: 2025.10.7
           install: true
           cache: true
 

--- a/.github/workflows/ci-tuist-unit_tests.yml
+++ b/.github/workflows/ci-tuist-unit_tests.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
           lfs: false

--- a/Workspace.swift
+++ b/Workspace.swift
@@ -38,3 +38,5 @@ let workspace = Workspace(
     name: "ios-monorepo",
     projects: projects
 )
+
+// nothing to do


### PR DESCRIPTION
- **👷 (tuist): Move runners to macos-latest**
- **👷 (workflows): Update actions/checkout to v5**
- **👷 (workflows): Update jdx/mise-action to use mise v2025.10.7**
- **👷 (build): Upgrade xcode to v26.0.1**
- **💩 (TO DELETE): Run ci**
