### PR TITLE
Fill magic card activity metadata

### DIFF
--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_magic_card-B2F89676DF8D4D3B89304A16EE1E55AF/curriculum_magic_card-B2F89676DF8D4D3B89304A16EE1E55AF.curriculum.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_magic_card-B2F89676DF8D4D3B89304A16EE1E55AF/curriculum_magic_card-B2F89676DF8D4D3B89304A16EE1E55AF.curriculum.yml
@@ -15,12 +15,15 @@ authors:
 
 skills:
   - recognition
-  - sensory_integration
+  - counting
+  - emotion_recognition
 
 tags:
   - colors
   - numbers
   - emotions
+  - geometric_shapes
+  - food
 
 locales:
   - en_US
@@ -29,25 +32,31 @@ locales:
 l10n:
   - locale: fr_FR
     details:
-      icon: letter_sounds_1
-      title: Sons des lettres 1
-      subtitle: A E I O U M
+      icon: magic_cards_activities
+      title: Cartes magiques
+      subtitle: Couleurs, formes, nombres et émotions
       abstract: |
-        Un parcours progressif pour apprendre à reconnaître les lettres de l’alphabet A E I O U M à travers des activités interactives.
+        Un parcours autour des cartes magiques pour reconnaître des couleurs, des formes, des nombres et des émotions.
 
       description: |
-        Ce parcours propose une série d’activités conçues pour aider le participant à associer le son des lettres à leur forme écrite. À l’aide d’instructions audio et d’illustrations visuelles, le participant est invité à écouter une lettre, puis à la retrouver sur l’écran. Une étape clé dans l’apprentissage de la lecture et de l’écriture.
+        Ce parcours propose une série d’activités interactives avec Leka et les cartes magiques.
+        Le participant observe ce que Leka affiche (couleurs, formes, nombres, émotions, aliments)
+        puis apporte la carte correspondante sur le front de Leka. Les activités renforcent la
+        reconnaissance visuelle, le comptage et l’identification des émotions.
 
   - locale: en_US
     details:
-      icon: letter_sounds_1
-      title: Letter Sounds 1
-      subtitle: A E I O U M
+      icon: magic_cards_activities
+      title: Magic cards
+      subtitle: Colors, shapes, numbers, and emotions
       abstract: |
-        A progressive curriculum to learn to recognize letters A E I O U M through engaging interactive activities.
+        A curriculum using magic cards to recognize colors, shapes, numbers, and emotions.
 
       description: |
-        This curriculum offers a set of activities designed to help the care receiver match the sound of each letter with its written form. With audio instructions and visual choices, participants are prompted to listen to a letter and identify it on the screen — a foundational skill for reading and writing.
+        This curriculum offers interactive activities with Leka and magic cards. The care receiver
+        observes what Leka shows (colors, shapes, numbers, emotions, foods) and brings the
+        matching card to Leka's forehead. The activities build visual recognition, counting,
+        and emotion identification skills.
 
 activities:
   - magic_card_number_recognition-16016A86DA0A4F5FB5FF9E457CA7B1A4

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_magic_card-B2F89676DF8D4D3B89304A16EE1E55AF/new_activities/magic_card_belt_color_recognition-D3E24B95730848329B122769B077E65C.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_magic_card-B2F89676DF8D4D3B89304A16EE1E55AF/new_activities/magic_card_belt_color_recognition-D3E24B95730848329B122769B077E65C.new_activity.yml
@@ -16,13 +16,11 @@ authors:
   - leka
 
 skills:
-  - <Skill 1>
-  - <Skill 2>
-  - <Skill 3>
+  - recognition
+  - discrimination
 
 tags:
-  - <Tag 1>
-  - <Tag 2>
+  - colors
 
 interaction:
   medium: tablet_robot
@@ -39,37 +37,40 @@ locales:
 l10n:
   - locale: fr_FR
     details:
-      icon: <nom de l'icone de l'activité>
+      icon: magic_cards_activities
 
-      title: <Titre de l'activité - FR>
-      subtitle: <Sous titre de l'activité - FR>
+      title: Couleurs de la ceinture
+      subtitle: Reconnaissance des couleurs
 
       short_description: |
-        <Courte description de l'activité - FR>
+        Identifier la couleur affichée par Leka et choisir la carte correspondante.
 
       description: |
-        <Description de l'activité - FR>
+        Leka change la couleur de sa ceinture lumineuse. Le participant observe la couleur
+        et doit apporter la carte magique associée. Cette activité entraîne la reconnaissance
+        et la discrimination des couleurs.
 
       instructions: |
-        - <Instruction étape 1 - FR>
-        - <Instruction étape 2 - FR>
+        - Observer la couleur affichée par la ceinture de Leka.
+        - Apporter la carte de la même couleur sur le front de Leka.
 
   - locale: en_US
     details:
-      icon: <nom de l'icone de l'activité>
+      icon: magic_cards_activities
 
-      title: <Titre de l'activité - EN>
-      subtitle: <Sous titre de l'activité - EN>
+      title: Belt colors
+      subtitle: Color recognition
 
       short_description: |
-        <Courte description de l'activité - EN>
+        Identify the color shown by Leka and select the matching card.
 
       description: |
-        <Description de l'activité - EN>
+        Leka changes the color of its belt. The care receiver observes the color and brings
+        the corresponding magic card. This activity practices color recognition and discrimination.
 
       instructions: |
-        - <Instruction étape 1 - EN>
-        - <Instruction étape 2 - EN>
+        - Observe the color shown on Leka's belt.
+        - Bring the matching color card to Leka's forehead.
 
 payload:
   options:

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_magic_card-B2F89676DF8D4D3B89304A16EE1E55AF/new_activities/magic_card_child_emotion_recognition-A40CA9F3F50A4FD58DB9FF40B7DC69BB.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_magic_card-B2F89676DF8D4D3B89304A16EE1E55AF/new_activities/magic_card_child_emotion_recognition-A40CA9F3F50A4FD58DB9FF40B7DC69BB.new_activity.yml
@@ -16,13 +16,11 @@ authors:
   - leka
 
 skills:
-  - <Skill 1>
-  - <Skill 2>
-  - <Skill 3>
+  - emotion_recognition
+  - recognition
 
 tags:
-  - <Tag 1>
-  - <Tag 2>
+  - emotions
 
 interaction:
   medium: tablet_robot
@@ -39,37 +37,41 @@ locales:
 l10n:
   - locale: fr_FR
     details:
-      icon: <nom de l'icone de l'activité>
+      icon: magic_cards_activities
 
-      title: <Titre de l'activité - FR>
-      subtitle: <Sous titre de l'activité - FR>
+      title: Émotions de l'enfant
+      subtitle: Reconnaissance des émotions
 
       short_description: |
-        <Courte description de l'activité - FR>
+        Associer l'émotion affichée par Leka à la carte de l'enfant correspondante.
 
       description: |
-        <Description de l'activité - FR>
+        Leka affiche une expression émotionnelle. Le participant doit identifier l'émotion
+        et apporter la carte magique représentant l'émotion d'un enfant. Cette activité
+        favorise la reconnaissance des émotions.
 
       instructions: |
-        - <Instruction étape 1 - FR>
-        - <Instruction étape 2 - FR>
+        - Observer l'expression affichée par Leka.
+        - Apporter la carte correspondant à l'émotion de l'enfant sur le front de Leka.
 
   - locale: en_US
     details:
-      icon: <nom de l'icone de l'activité>
+      icon: magic_cards_activities
 
-      title: <Titre de l'activité - EN>
-      subtitle: <Sous titre de l'activité - EN>
+      title: Child emotions
+      subtitle: Emotion recognition
 
       short_description: |
-        <Courte description de l'activité - EN>
+        Match the emotion shown by Leka with the child's emotion card.
 
       description: |
-        <Description de l'activité - EN>
+        Leka shows an emotional expression. The care receiver identifies the emotion and
+        brings the magic card that represents a child's emotion. This activity strengthens
+        emotion recognition.
 
       instructions: |
-        - <Instruction étape 1 - EN>
-        - <Instruction étape 2 - EN>
+        - Observe the expression shown by Leka.
+        - Bring the child's emotion card to Leka's forehead.
 
 payload:
   options:

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_magic_card-B2F89676DF8D4D3B89304A16EE1E55AF/new_activities/magic_card_flash_counting-F49E8F55AA7D4DA3A1216194C211236D.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_magic_card-B2F89676DF8D4D3B89304A16EE1E55AF/new_activities/magic_card_flash_counting-F49E8F55AA7D4DA3A1216194C211236D.new_activity.yml
@@ -16,13 +16,11 @@ authors:
   - leka
 
 skills:
-  - <Skill 1>
-  - <Skill 2>
-  - <Skill 3>
+  - counting
+  - recognition
 
 tags:
-  - <Tag 1>
-  - <Tag 2>
+  - numbers
 
 interaction:
   medium: tablet_robot
@@ -39,37 +37,39 @@ locales:
 l10n:
   - locale: fr_FR
     details:
-      icon: <nom de l'icone de l'activité>
+      icon: magic_cards_activities
 
-      title: <Titre de l'activité - FR>
-      subtitle: <Sous titre de l'activité - FR>
+      title: Compter les flashes
+      subtitle: Cartes 1 à 6
 
       short_description: |
-        <Courte description de l'activité - FR>
+        Compter les flashes de Leka et présenter la carte du bon nombre.
 
       description: |
-        <Description de l'activité - FR>
+        Leka clignote un certain nombre de fois. Le participant compte les flashes
+        puis apporte la carte magique avec le nombre correspondant.
 
       instructions: |
-        - <Instruction étape 1 - FR>
-        - <Instruction étape 2 - FR>
+        - Compter les flashes de Leka.
+        - Apporter la carte du nombre correspondant sur le front de Leka.
 
   - locale: en_US
     details:
-      icon: <nom de l'icone de l'activité>
+      icon: magic_cards_activities
 
-      title: <Titre de l'activité - EN>
-      subtitle: <Sous titre de l'activité - EN>
+      title: Count the flashes
+      subtitle: Cards 1 to 6
 
       short_description: |
-        <Courte description de l'activité - EN>
+        Count Leka's flashes and present the correct number card.
 
       description: |
-        <Description de l'activité - EN>
+        Leka flashes a number of times. The care receiver counts the flashes
+        and brings the magic card with the matching number.
 
       instructions: |
-        - <Instruction étape 1 - EN>
-        - <Instruction étape 2 - EN>
+        - Count the flashes from Leka.
+        - Bring the matching number card to Leka's forehead.
 
 payload:
   options:

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_magic_card-B2F89676DF8D4D3B89304A16EE1E55AF/new_activities/magic_card_food_recognition-3A1F64691EC0478FB5FB52546F28963D.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_magic_card-B2F89676DF8D4D3B89304A16EE1E55AF/new_activities/magic_card_food_recognition-3A1F64691EC0478FB5FB52546F28963D.new_activity.yml
@@ -16,13 +16,13 @@ authors:
   - leka
 
 skills:
-  - <Skill 1>
-  - <Skill 2>
-  - <Skill 3>
+  - recognition
+  - discrimination
 
 tags:
-  - <Tag 1>
-  - <Tag 2>
+  - food
+  - fruits
+  - vegetables
 
 interaction:
   medium: tablet_robot
@@ -39,37 +39,40 @@ locales:
 l10n:
   - locale: fr_FR
     details:
-      icon: <nom de l'icone de l'activité>
+      icon: magic_cards_activities
 
-      title: <Titre de l'activité - FR>
-      subtitle: <Sous titre de l'activité - FR>
+      title: Fruits et légumes
+      subtitle: Reconnaissance des aliments
 
       short_description: |
-        <Courte description de l'activité - FR>
+        Reconnaître les aliments affichés et choisir la carte magique correspondante.
 
       description: |
-        <Description de l'activité - FR>
+        Leka présente des fruits et des légumes. Le participant observe l'aliment affiché
+        et apporte la carte magique associée. Cette activité développe la reconnaissance
+        visuelle des aliments.
 
       instructions: |
-        - <Instruction étape 1 - FR>
-        - <Instruction étape 2 - FR>
+        - Observer l'aliment affiché par Leka.
+        - Apporter la carte correspondante sur le front de Leka.
 
   - locale: en_US
     details:
-      icon: <nom de l'icone de l'activité>
+      icon: magic_cards_activities
 
-      title: <Titre de l'activité - EN>
-      subtitle: <Sous titre de l'activité - EN>
+      title: Fruits and vegetables
+      subtitle: Food recognition
 
       short_description: |
-        <Courte description de l'activité - EN>
+        Recognize the food shown and select the matching magic card.
 
       description: |
-        <Description de l'activité - EN>
+        Leka shows fruits and vegetables. The care receiver observes the food item and brings
+        the corresponding magic card. This activity builds visual food recognition skills.
 
       instructions: |
-        - <Instruction étape 1 - EN>
-        - <Instruction étape 2 - EN>
+        - Observe the food item shown by Leka.
+        - Bring the matching card to Leka's forehead.
 
 payload:
   options:

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_magic_card-B2F89676DF8D4D3B89304A16EE1E55AF/new_activities/magic_card_leka_emotion_recognition-6BFDE930EBA7462AAC828D09843D7747.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_magic_card-B2F89676DF8D4D3B89304A16EE1E55AF/new_activities/magic_card_leka_emotion_recognition-6BFDE930EBA7462AAC828D09843D7747.new_activity.yml
@@ -16,13 +16,11 @@ authors:
   - leka
 
 skills:
-  - <Skill 1>
-  - <Skill 2>
-  - <Skill 3>
+  - emotion_recognition
+  - recognition
 
 tags:
-  - <Tag 1>
-  - <Tag 2>
+  - emotions
 
 interaction:
   medium: tablet_robot
@@ -39,37 +37,41 @@ locales:
 l10n:
   - locale: fr_FR
     details:
-      icon: <nom de l'icone de l'activité>
+      icon: magic_cards_activities
 
-      title: <Titre de l'activité - FR>
-      subtitle: <Sous titre de l'activité - FR>
+      title: Émotions de Leka
+      subtitle: Reconnaissance des émotions
 
       short_description: |
-        <Courte description de l'activité - FR>
+        Identifier l'émotion de Leka et présenter la carte correspondante.
 
       description: |
-        <Description de l'activité - FR>
+        Leka affiche une expression émotionnelle. Le participant identifie l'émotion
+        et apporte la carte magique représentant l'émotion de Leka. Cette activité
+        aide à reconnaître les émotions.
 
       instructions: |
-        - <Instruction étape 1 - FR>
-        - <Instruction étape 2 - FR>
+        - Observer l'expression affichée par Leka.
+        - Apporter la carte de l'émotion de Leka sur le front de Leka.
 
   - locale: en_US
     details:
-      icon: <nom de l'icone de l'activité>
+      icon: magic_cards_activities
 
-      title: <Titre de l'activité - EN>
-      subtitle: <Sous titre de l'activité - EN>
+      title: Leka emotions
+      subtitle: Emotion recognition
 
       short_description: |
-        <Courte description de l'activité - EN>
+        Identify Leka's emotion and present the matching card.
 
       description: |
-        <Description de l'activité - EN>
+        Leka displays an emotional expression. The care receiver identifies the emotion
+        and brings the magic card representing Leka's emotion. This activity supports
+        emotion recognition.
 
       instructions: |
-        - <Instruction étape 1 - EN>
-        - <Instruction étape 2 - EN>
+        - Observe the expression shown by Leka.
+        - Bring Leka's emotion card to Leka's forehead.
 
 payload:
   options:

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_magic_card-B2F89676DF8D4D3B89304A16EE1E55AF/new_activities/magic_card_number_recognition-16016A86DA0A4F5FB5FF9E457CA7B1A4.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_magic_card-B2F89676DF8D4D3B89304A16EE1E55AF/new_activities/magic_card_number_recognition-16016A86DA0A4F5FB5FF9E457CA7B1A4.new_activity.yml
@@ -5,7 +5,7 @@
 version: 2.0.0
 
 uuid: 16016A86DA0A4F5FB5FF9E457CA7B1A4
-name: <Titre>
+name: magic_card_number_recognition
 
 created_at: "2024-06-17T17:38:12.804177"
 last_edited_at: "2026-01-19T22:41:15.645198"
@@ -16,13 +16,11 @@ authors:
   - leka
 
 skills:
-  - <Skill 1>
-  - <Skill 2>
-  - <Skill 3>
+  - recognition
+  - counting
 
 tags:
-  - <Tag 1>
-  - <Tag 2>
+  - numbers
 
 interaction:
   medium: tablet_robot
@@ -39,37 +37,39 @@ locales:
 l10n:
   - locale: fr_FR
     details:
-      icon: <nom de l'icone de l'activité>
+      icon: magic_cards_activities
 
-      title: <Titre de l'activité - FR>
-      subtitle: <Sous titre de l'activité - FR>
+      title: Reconnaissance des nombres
+      subtitle: Cartes 1 à 6
 
       short_description: |
-        <Courte description de l'activité - FR>
+        Une activité pour reconnaître les nombres grâce aux cartes magiques.
 
       description: |
-        <Description de l'activité - FR>
+        Leka affiche un nombre et le participant doit identifier la carte magique correspondante.
+        Cette activité renforce la reconnaissance des nombres et l'association visuelle.
 
       instructions: |
-        - <Instruction étape 1 - FR>
-        - <Instruction étape 2 - FR>
+        - Observer le nombre affiché par Leka.
+        - Apporter la carte correspondante sur le front de Leka.
 
   - locale: en_US
     details:
-      icon: <nom de l'icone de l'activité>
+      icon: magic_cards_activities
 
-      title: <Titre de l'activité - EN>
-      subtitle: <Sous titre de l'activité - EN>
+      title: Number recognition
+      subtitle: Cards 1 to 6
 
       short_description: |
-        <Courte description de l'activité - EN>
+        An activity to recognize numbers using magic cards.
 
       description: |
-        <Description de l'activité - EN>
+        Leka displays a number and the care receiver selects the matching magic card.
+        This activity supports number recognition and visual association.
 
       instructions: |
-        - <Instruction étape 1 - EN>
-        - <Instruction étape 2 - EN>
+        - Observe the number displayed by Leka.
+        - Bring the matching card to Leka's forehead.
 
 payload:
   options:

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_magic_card-B2F89676DF8D4D3B89304A16EE1E55AF/new_activities/magic_card_screen_color_recognition-64C2CDF7DAA240CEB195F1BBE13941E3.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_magic_card-B2F89676DF8D4D3B89304A16EE1E55AF/new_activities/magic_card_screen_color_recognition-64C2CDF7DAA240CEB195F1BBE13941E3.new_activity.yml
@@ -16,13 +16,11 @@ authors:
   - leka
 
 skills:
-  - <Skill 1>
-  - <Skill 2>
-  - <Skill 3>
+  - recognition
+  - discrimination
 
 tags:
-  - <Tag 1>
-  - <Tag 2>
+  - colors
 
 interaction:
   medium: tablet_robot
@@ -39,37 +37,40 @@ locales:
 l10n:
   - locale: fr_FR
     details:
-      icon: <nom de l'icone de l'activité>
+      icon: magic_cards_activities
 
-      title: <Titre de l'activité - FR>
-      subtitle: <Sous titre de l'activité - FR>
+      title: Couleurs à l'écran
+      subtitle: Reconnaissance des couleurs
 
       short_description: |
-        <Courte description de l'activité - FR>
+        Retrouver la couleur affichée sur l'écran de Leka avec la bonne carte.
 
       description: |
-        <Description de l'activité - FR>
+        Leka affiche une couleur sur son écran. Le participant doit choisir la carte magique
+        correspondant à cette couleur. Cette activité développe la reconnaissance visuelle
+        des couleurs.
 
       instructions: |
-        - <Instruction étape 1 - FR>
-        - <Instruction étape 2 - FR>
+        - Regarder la couleur affichée sur l'écran de Leka.
+        - Apporter la carte de la même couleur sur le front de Leka.
 
   - locale: en_US
     details:
-      icon: <nom de l'icone de l'activité>
+      icon: magic_cards_activities
 
-      title: <Titre de l'activité - EN>
-      subtitle: <Sous titre de l'activité - EN>
+      title: Screen colors
+      subtitle: Color recognition
 
       short_description: |
-        <Courte description de l'activité - EN>
+        Match the color shown on Leka's screen with the correct card.
 
       description: |
-        <Description de l'activité - EN>
+        Leka displays a color on its screen. The care receiver selects the magic card that
+        matches the color. This activity strengthens visual color recognition.
 
       instructions: |
-        - <Instruction étape 1 - EN>
-        - <Instruction étape 2 - EN>
+        - Look at the color shown on Leka's screen.
+        - Bring the matching color card to Leka's forehead.
 
 payload:
   options:

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_magic_card-B2F89676DF8D4D3B89304A16EE1E55AF/new_activities/magic_card_shape_recognition-DBB673D31BBE44448EEAE59657C51C89.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_magic_card-B2F89676DF8D4D3B89304A16EE1E55AF/new_activities/magic_card_shape_recognition-DBB673D31BBE44448EEAE59657C51C89.new_activity.yml
@@ -16,13 +16,11 @@ authors:
   - leka
 
 skills:
-  - <Skill 1>
-  - <Skill 2>
-  - <Skill 3>
+  - recognition
+  - discrimination
 
 tags:
-  - <Tag 1>
-  - <Tag 2>
+  - geometric_shapes
 
 interaction:
   medium: tablet_robot
@@ -39,37 +37,40 @@ locales:
 l10n:
   - locale: fr_FR
     details:
-      icon: <nom de l'icone de l'activité>
+      icon: magic_cards_activities
 
-      title: <Titre de l'activité - FR>
-      subtitle: <Sous titre de l'activité - FR>
+      title: Reconnaissance des formes
+      subtitle: Carré, cercle, triangle, étoile
 
       short_description: |
-        <Courte description de l'activité - FR>
+        Associer la forme affichée par Leka à la bonne carte magique.
 
       description: |
-        <Description de l'activité - FR>
+        Leka affiche une forme géométrique. Le participant doit identifier la forme et
+        présenter la carte correspondante. L'activité renforce la reconnaissance et la
+        discrimination des formes.
 
       instructions: |
-        - <Instruction étape 1 - FR>
-        - <Instruction étape 2 - FR>
+        - Observer la forme affichée par Leka.
+        - Apporter la carte de la même forme sur le front de Leka.
 
   - locale: en_US
     details:
-      icon: <nom de l'icone de l'activité>
+      icon: magic_cards_activities
 
-      title: <Titre de l'activité - EN>
-      subtitle: <Sous titre de l'activité - EN>
+      title: Shape recognition
+      subtitle: Square, circle, triangle, star
 
       short_description: |
-        <Courte description de l'activité - EN>
+        Match the shape shown by Leka with the correct magic card.
 
       description: |
-        <Description de l'activité - EN>
+        Leka displays a geometric shape. The care receiver identifies the shape and presents
+        the matching card. This activity strengthens shape recognition and discrimination.
 
       instructions: |
-        - <Instruction étape 1 - EN>
-        - <Instruction étape 2 - EN>
+        - Observe the shape shown by Leka.
+        - Bring the matching shape card to Leka's forehead.
 
 payload:
   options:

--- a/Modules/ContentKit/Resources/Content/curriculums/curriculum_magic_card-B2F89676DF8D4D3B89304A16EE1E55AF/new_activities/magic_card_spot_counting-191C6D9723FA41759E24B9BD86543CDF.new_activity.yml
+++ b/Modules/ContentKit/Resources/Content/curriculums/curriculum_magic_card-B2F89676DF8D4D3B89304A16EE1E55AF/new_activities/magic_card_spot_counting-191C6D9723FA41759E24B9BD86543CDF.new_activity.yml
@@ -16,13 +16,11 @@ authors:
   - leka
 
 skills:
-  - <Skill 1>
-  - <Skill 2>
-  - <Skill 3>
+  - counting
+  - recognition
 
 tags:
-  - <Tag 1>
-  - <Tag 2>
+  - numbers
 
 interaction:
   medium: tablet_robot
@@ -39,37 +37,39 @@ locales:
 l10n:
   - locale: fr_FR
     details:
-      icon: <nom de l'icone de l'activité>
+      icon: magic_cards_activities
 
-      title: <Titre de l'activité - FR>
-      subtitle: <Sous titre de l'activité - FR>
+      title: Compter les points
+      subtitle: Cartes 1 à 6
 
       short_description: |
-        <Courte description de l'activité - FR>
+        Compter les points affichés et choisir la carte magique correspondante.
 
       description: |
-        <Description de l'activité - FR>
+        Leka affiche des points sur son écran. Le participant compte les points
+        puis apporte la carte magique avec le bon nombre.
 
       instructions: |
-        - <Instruction étape 1 - FR>
-        - <Instruction étape 2 - FR>
+        - Compter les points affichés par Leka.
+        - Apporter la carte du nombre correspondant sur le front de Leka.
 
   - locale: en_US
     details:
-      icon: <nom de l'icone de l'activité>
+      icon: magic_cards_activities
 
-      title: <Titre de l'activité - EN>
-      subtitle: <Sous titre de l'activité - EN>
+      title: Count the dots
+      subtitle: Cards 1 to 6
 
       short_description: |
-        <Courte description de l'activité - EN>
+        Count the dots shown and choose the matching magic card.
 
       description: |
-        <Description de l'activité - EN>
+        Leka displays dots on its screen. The care receiver counts the dots
+        and brings the magic card with the correct number.
 
       instructions: |
-        - <Instruction étape 1 - EN>
-        - <Instruction étape 2 - EN>
+        - Count the dots shown by Leka.
+        - Bring the matching number card to Leka's forehead.
 
 payload:
   options:


### PR DESCRIPTION
### Motivation
- Replace placeholder tokens in nine magic card activity YAMLs and the copied curriculum to provide concrete metadata for skills, tags and localized copy.
- Ensure skills/tags reference canonical identifiers from `Modules/ContentKit/Resources/Content/definitions/skills.yml` and `tags.yml` rather than freeform placeholders.
- Provide French and English `l10n` (icon, title, subtitle, short_description, description, instructions) so the activities are ready for content ingestion and display.

### Description
- Updated the magic card curriculum resource and nine activity resources under `Modules/ContentKit/Resources/Content/curriculums/curriculum_magic_card-...` to replace placeholders with concrete values and localized copy.
- Replaced skills placeholders with IDs such as `recognition`, `counting`, and `emotion_recognition` (from `definitions/skills.yml`) and tags with IDs such as `numbers`, `colors`, `geometric_shapes`, `food`, `fruits`, `vegetables`, and `emotions` (from `definitions/tags.yml`).
- Filled `l10n` for both `fr_FR` and `en_US` across activities and the curriculum, and set the activity icon to `magic_cards_activities` where appropriate.
- Files changed: the curriculum YAML and nine `*.new_activity.yml` files for the magic card activities (number recognition, belt/screen color recognition, shape recognition, foods, child/Leka emotion recognition, flash counting, and spot counting). In total the resource updates provide completed metadata and localized descriptions for the new activity set.

### Testing
- No automated tests were run for this change; these are content-only YAML updates and should be validated by the repository's content validation pipeline or CI content checks after review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697747d34fc48320a5d7fc9f7e833cf2)