### PR TITLE
✨ (LekaApp): Highlight new activity experience in Home curation

### DIFF
--- a/Apps/LekaApp/Sources/Views/Components/FeaturedCurationView.swift
+++ b/Apps/LekaApp/Sources/Views/Components/FeaturedCurationView.swift
@@ -1,0 +1,119 @@
+// Leka - iOS Monorepo
+// Copyright APF France handicap
+// SPDX-License-Identifier: Apache-2.0
+
+import AnalyticsKit
+import ContentKit
+import SwiftUI
+
+// MARK: - FeaturedCurationView
+
+public struct FeaturedCurationView: View {
+    // MARK: Public
+
+    public var body: some View {
+        if let item = self.section.items.first,
+           item.contentType == .curation,
+           let curation = CategoryCuration(id: item.id)
+        {
+            NavigationLink(destination:
+                AnyView(self.navigation.curationDestination(item)))
+            {
+                HStack(spacing: 24) {
+                    self.icon(for: curation)
+                        .frame(width: 92, height: 92)
+                        .padding(22)
+                        .background(.white.opacity(0.18), in: RoundedRectangle(cornerRadius: 28))
+
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text(self.section.details.title)
+                            .font(.largeTitle.bold())
+                            .foregroundStyle(.white)
+
+                        if self.section.details.description != "" {
+                            Text(self.section.details.description)
+                                .font(.title3)
+                                .foregroundStyle(.white.opacity(0.9))
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+
+                        if self.section.details.subtitle != "" {
+                            HStack(spacing: 8) {
+                                Text(self.section.details.subtitle)
+                                    .font(.headline.bold())
+
+                                Image(systemName: "arrow.right")
+                                    .font(.headline.bold())
+                            }
+                            .foregroundStyle(curation.color)
+                            .padding(.horizontal, 18)
+                            .padding(.vertical, 12)
+                            .background(.white, in: Capsule())
+                            .padding(.top, 4)
+                        }
+                    }
+
+                    Spacer(minLength: 0)
+                }
+                .padding(32)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(
+                    LinearGradient(
+                        colors: [curation.color, curation.color.opacity(0.78)],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    ),
+                    in: RoundedRectangle(cornerRadius: 32)
+                )
+                .overlay(alignment: .topTrailing) {
+                    Image(systemName: "sparkles")
+                        .font(.system(size: 70, weight: .bold))
+                        .foregroundStyle(.white.opacity(0.12))
+                        .padding(28)
+                }
+                .padding(.horizontal)
+            }
+            .buttonStyle(.plain)
+            .simultaneousGesture(TapGesture().onEnded {
+                AnalyticsManager.logEventSelectContent(
+                    type: .curation,
+                    id: item.id,
+                    name: item.name,
+                    origin: self.navigation.selectedCategory?.rawValue
+                )
+            })
+        }
+    }
+
+    // MARK: Internal
+
+    let section: CategoryCuration.Section
+
+    // MARK: Private
+
+    @State private var navigation: Navigation = .shared
+
+    @ViewBuilder
+    private func icon(for curation: CategoryCuration) -> some View {
+        if let icon = UIImage(named: "\(curation.icon).skill.icon.png", in: .module, with: nil) {
+            Image(uiImage: icon)
+                .renderingMode(.template)
+                .resizable()
+                .scaledToFit()
+                .foregroundStyle(.white)
+        } else {
+            Image(systemName: curation.icon)
+                .resizable()
+                .scaledToFit()
+                .foregroundStyle(.white)
+        }
+    }
+}
+
+#Preview {
+    let homeCuration = ContentKit.allCurations[MainCurations.home.rawValue]!
+
+    return ScrollView {
+        FeaturedCurationView(section: homeCuration.sections[0])
+    }
+}

--- a/Apps/LekaApp/Sources/Views/Curation/CurationSeeMoreFactory.swift
+++ b/Apps/LekaApp/Sources/Views/Curation/CurationSeeMoreFactory.swift
@@ -14,7 +14,8 @@ public struct CurationSeeMoreFactory: View {
     public var body: some View {
         ScrollView(showsIndicators: false) {
             switch self.section.componentType {
-                case .carousel:
+                case .carousel,
+                     .featuredCuration:
                     Text("None")
                 case .horizontalCurriculumGrid,
                      .horizontalCurriculumList,

--- a/Apps/LekaApp/Sources/Views/Curation/CurationView.swift
+++ b/Apps/LekaApp/Sources/Views/Curation/CurationView.swift
@@ -65,7 +65,9 @@ struct CurationView: View {
                 ForEach(self.curation.sections) { section in
                     Section {
                         VStack(alignment: .leading, spacing: 5) {
-                            if section.details.title != "" {
+                            if section.componentType != .featuredCuration,
+                               section.details.title != ""
+                            {
                                 VStack(alignment: .leading) {
                                     HStack {
                                         Text(section.details.title)

--- a/Apps/LekaApp/Sources/Views/Curation/CurationViewFactory.swift
+++ b/Apps/LekaApp/Sources/Views/Curation/CurationViewFactory.swift
@@ -14,6 +14,8 @@ public struct CurationViewFactory: View {
         switch self.section.componentType {
             case .carousel:
                 CarouselView(items: self.section.items)
+            case .featuredCuration:
+                FeaturedCurationView(section: self.section)
             case .horizontalCurriculumGrid:
                 HorizontalCurriculumGrid(items: self.section.items)
             case .horizontalActivityGrid:

--- a/Modules/ContentKit/Resources/Content/curations/home-F4E2C104C09E436CB80A87749CE62DDF.curation.yml
+++ b/Modules/ContentKit/Resources/Content/curations/home-F4E2C104C09E436CB80A87749CE62DDF.curation.yml
@@ -19,6 +19,22 @@ l10n:
       description:
 
 content:
+  - component: featured_curation
+    l10n:
+      - locale: fr_FR
+        details:
+          title: Les activités font peau neuve !
+          subtitle: Découvrir les nouveautés
+          description: Découvrez des interfaces améliorées, de meilleurs retours pendant le jeu et de nouvelles activités Cartes magiques avec Leka.
+      - locale: en_US
+        details:
+          title: New activities are here!
+          subtitle: Discover what’s new
+          description: Discover refreshed interfaces, improved feedback during play, and new Magic Cards activities to explore with Leka.
+    items:
+      - value: new_activity_experience-8C9912C8656F4C65AF52CB94EF143037
+        type: curation
+
   - component: carousel
     l10n:
       - locale: fr_FR
@@ -34,57 +50,17 @@ content:
     items:
       - value: curriculum_magic_card-B2F89676DF8D4D3B89304A16EE1E55AF
         type: curriculum
-      - value: color_mediator-2CE6B5E98AFD45E0B2CD87727DB6D5C2
-        type: activity
-      - value: curriculum_recognition_family_members-AD1A9E2D874C47AEB3445D80E34DC702
+      - value: curriculum_openplay_feelings-2196E84ADF24439AA51CAB93000C95F3
         type: curriculum
-      - value: curriculum_recognition_garden_items-A1006027902E44C0B38BC3D3BAEDD4F6
-        type: curriculum
-      - value: curriculum_sort_objects_by_location-CC406024F40C4834A66BB7C8F0E8C0AD
-        type: curriculum
-      - value: curriculum_recognition_seaside_holidays-B1BA5597BC594082AECE293AD25CFA89
-        type: curriculum
-      - value: curriculum_animal_memory-7C75908B86D748A283AA080D40642BE7
-        type: curriculum
-      - value: sequencing_daily_life_toilets-8D126A04F37D4E8BA498EE4758E071AC
-        type: activity
-
-  - component: horizontal_curriculum_list
-    l10n:
-      - locale: fr_FR
-        details:
-          title: Nouveautés
-          subtitle:
-          description: Les derniers ajouts à découvrir.
-      - locale: en_US
-        details:
-          title: New Arrivals
-          subtitle:
-          description: The latest to explore.
-    items:
       - value: curriculum_shape_recognition-785607C27B1449A1B12F10302A754486
         type: curriculum
+      - value: curriculum_openplay_preferences_animal-E4E20B090D3C4D898C139513D85E9B45
+        type: curriculum
+      - value: curriculum_openplay_preferences_food-0AD93266F427408CA13C61C4B8F68E3C
+        type: curriculum
+      - value: curriculum_openplay_preferences_sports-F72441F55BAA48A78E359A4EFCC6E007
+        type: curriculum
       - value: curriculum_visual_discrimination_shapes_and_colors-B142C14603F246C7B88C169E2CD3FF74
-        type: curriculum
-      - value: curriculum_recognition_alphabet_letters_1-27A711E56A4140C4A69FCAF0E4CD5410
-        type: curriculum
-      - value: curriculum_alphabet_letters_sounds_1-C157BAD4AA044EE89A941B1D868FFEB7
-        type: curriculum
-      - value: curriculum_alphabetical_order-F9A2F6E76AE449999B1F76AA7E2D2978
-        type: curriculum
-      - value: curriculum_ordering_steps_to_bake_a_cake-1F908FA3349B476DA1EE4CDC60B5B632
-        type: curriculum
-      - value: curriculum_ordering_the_steps_of_a_session_with_leka-211497313FDB4094990330D2387D1CA3
-        type: curriculum
-      - value: curriculum_recognition_cooked_fruits-C0D2DAE8152F4CAE863EAEBF815354BA
-        type: curriculum
-      - value: curriculum_recognition_cooked_vegetables-655C2A62DB644DAABC8A286025231418
-        type: curriculum
-      - value: curriculum_recognition_emotions_robot-B63B1180ECAF46269402C0AD2F20191A
-        type: curriculum
-      - value: curriculum_leka_weather_robot-ED4C900D4ACB426384DC76F182BC19A5
-        type: curriculum
-      - value: curriculum_ordering_of_life_stages-ADC51847C6FA4C58BA5210D02C030477
         type: curriculum
 
   - component: horizontal_curriculum_grid

--- a/Modules/ContentKit/Resources/Content/curations/subcurations/new_activity_experience-8C9912C8656F4C65AF52CB94EF143037.curation.yml
+++ b/Modules/ContentKit/Resources/Content/curations/subcurations/new_activity_experience-8C9912C8656F4C65AF52CB94EF143037.curation.yml
@@ -1,0 +1,156 @@
+# Leka - iOS Monorepo
+# Copyright APF France handicap
+# SPDX-License-Identifier: Apache-2.0
+
+uuid: 8C9912C8656F4C65AF52CB94EF143037
+icon: sparkles
+color: 0x7856FF
+
+l10n:
+  - locale: fr_FR
+    details:
+      title: Nouvelle expérience des activités
+      subtitle:
+      description: Des interfaces plus claires, un jeu plus fluide et de nouvelles façons d’interagir avec Leka.
+  - locale: en_US
+    details:
+      title: New activity experience
+      subtitle:
+      description: Cleaner interfaces, smoother play, and new ways to interact with Leka.
+
+content:
+  - component: horizontal_curriculum_content_grid
+    l10n:
+      - locale: fr_FR
+        details:
+          title: "Nouvelle interaction : Cartes magiques"
+          subtitle:
+          description: Découvrez les activités Cartes magiques avec Leka.
+      - locale: en_US
+        details:
+          title: "New interaction: Magic Cards"
+          subtitle:
+          description: Discover Magic Cards activities with Leka.
+    items:
+      - value: curriculum_magic_card-B2F89676DF8D4D3B89304A16EE1E55AF
+        type: curriculum
+
+  - component: horizontal_activity_list
+    l10n:
+      - locale: fr_FR
+        details:
+          title: Jeux éducatifs améliorés
+          subtitle:
+          description: Les activités autonomes mises à jour pour la nouvelle expérience.
+      - locale: en_US
+        details:
+          title: Refreshed educational games
+          subtitle:
+          description: Standalone activities updated for the new experience.
+    items:
+      - value: dance_freeze-6E2F7D56726C419EA534C614F777D934
+        type: activity
+      - value: hide_and_seek-4BFA2AC3390E49248DD022E27008F118
+        type: activity
+      - value: melody-CB995F829411449AB32E6B8A688E3DDB
+        type: activity
+      - value: color_music_pad-8439D1EE7DD846ACB048145089F34C33
+        type: activity
+      - value: xylophone_pentatonic-7C1DDED6C6D44913B9A7D4EB4AEE8F6B
+        type: activity
+      - value: xylophone_heptatonic-65193102AE2947439ABB82D5891EDDBA
+        type: activity
+      - value: color_mediator-2CE6B5E98AFD45E0B2CD87727DB6D5C2
+        type: activity
+      - value: discover_leka-89CEA9FE20624659B1307B633641BC90
+        type: activity
+      - value: super_simon_2_colors-3E4B57F536824F1087A2E512223EF7E0
+        type: activity
+      - value: super_simon_4_colors-B39DDA35800849F7A40F651E411D30CD
+        type: activity
+      - value: super_simon_6_colors-9EFAAC01288F41C0ACACCA5094FAD8E7
+        type: activity
+
+  - component: horizontal_curriculum_grid
+    l10n:
+      - locale: fr_FR
+        details:
+          title: Activités améliorées
+          subtitle:
+          description: Des contenus connus, mis à jour pour une expérience plus fluide.
+      - locale: en_US
+        details:
+          title: Refreshed activities
+          subtitle:
+          description: Familiar content updated for a smoother experience.
+    items:
+      - value: curriculum_animal_memory-7C75908B86D748A283AA080D40642BE7
+        type: curriculum
+      - value: color_bingo-69760D1DA61849E3926E3A939BBEF0CE
+        type: curriculum
+      - value: curriculum_alphabetical_order-F9A2F6E76AE449999B1F76AA7E2D2978
+        type: curriculum
+      - value: curriculum_ordering_steps_to_bake_a_cake-1F908FA3349B476DA1EE4CDC60B5B632
+        type: curriculum
+      - value: curriculum_ordering_the_steps_of_a_session_with_leka-211497313FDB4094990330D2387D1CA3
+        type: curriculum
+      - value: curriculum_leka_weather_robot-ED4C900D4ACB426384DC76F182BC19A5
+        type: curriculum
+      - value: curriculum_recognition_emotions_robot-B63B1180ECAF46269402C0AD2F20191A
+        type: curriculum
+      - value: super_simon-C6EABAC161CD44C290B32202DFDCDAF6
+        type: curriculum
+
+  - component: horizontal_curriculum_list
+    l10n:
+      - locale: fr_FR
+        details:
+          title: Nouveaux parcours pour parler de soi
+          subtitle:
+          description: Des parcours sans bonne ou mauvaise réponse pour aider à exprimer ses goûts, ses envies et ses ressentis.
+      - locale: en_US
+        details:
+          title: New curriculums to talk about oneself
+          subtitle:
+          description: Curriculums without right or wrong answers to help express one's tastes, desires, and feelings.
+    items:
+      - value: curriculum_openplay_feelings-2196E84ADF24439AA51CAB93000C95F3
+        type: curriculum
+      - value: curriculum_openplay_preferences_animal-E4E20B090D3C4D898C139513D85E9B45
+        type: curriculum
+      - value: curriculum_openplay_preferences_food-0AD93266F427408CA13C61C4B8F68E3C
+        type: curriculum
+      - value: curriculum_openplay_preferences_sports-F72441F55BAA48A78E359A4EFCC6E007
+        type: curriculum
+
+  - component: horizontal_curriculum_content_grid
+    l10n:
+      - locale: fr_FR
+        details:
+          title: Nouveaux parcours sur les formes
+          subtitle:
+          description: De tout nouveaux parcours pour apprendre les formes.
+      - locale: en_US
+        details:
+          title: New curriculums on shapes
+          subtitle:
+          description: Brand new curriculums to learn shapes.
+    items:
+      - value: curriculum_shape_recognition-785607C27B1449A1B12F10302A754486
+        type: curriculum
+
+  - component: horizontal_curriculum_content_grid
+    l10n:
+      - locale: fr_FR
+        details:
+          title:
+          subtitle:
+          description:
+      - locale: en_US
+        details:
+          title:
+          subtitle:
+          description:
+    items:
+      - value: curriculum_visual_discrimination_shapes_and_colors-B142C14603F246C7B88C169E2CD3FF74
+        type: curriculum

--- a/Modules/ContentKit/Sources/Content/_NewSystem/Categories/Category+Curation.swift
+++ b/Modules/ContentKit/Sources/Content/_NewSystem/Categories/Category+Curation.swift
@@ -78,6 +78,7 @@ public extension CategoryCuration {
 
         public enum ComponentType: String, Codable {
             case carousel
+            case featuredCuration = "featured_curation"
             case horizontalCurriculumGrid = "horizontal_curriculum_grid"
             case horizontalActivityGrid = "horizontal_activity_grid"
             case horizontalCurriculumContentGrid = "horizontal_curriculum_content_grid"


### PR DESCRIPTION
## Summary

- Add a curation-driven featured Home card for the new activity experience.
- Create the dedicated New activity experience curation with Magic Cards, new curriculums, refreshed curriculums, and refreshed standalone activities.
- Refresh Home sections so the new experience and updated standalone educational games are visible near the top while popular sections remain below.

closes #2037

## Tests

- `swiftformat Apps/LekaApp/Sources/Views/Components/FeaturedCurationView.swift Apps/LekaApp/Sources/Views/Curation/CurationView.swift Apps/LekaApp/Sources/Views/Curation/CurationViewFactory.swift Apps/LekaApp/Sources/Views/Curation/CurationSeeMoreFactory.swift Modules/ContentKit/Sources/Content/_NewSystem/Categories/Category+Curation.swift`
- `swiftlint lint --config .swiftlint.yml --strict Apps/LekaApp/Sources/Views/Components/FeaturedCurationView.swift Apps/LekaApp/Sources/Views/Curation/CurationView.swift Apps/LekaApp/Sources/Views/Curation/CurationViewFactory.swift Apps/LekaApp/Sources/Views/Curation/CurationSeeMoreFactory.swift Modules/ContentKit/Sources/Content/_NewSystem/Categories/Category+Curation.swift`
- YAML parse check for updated/new curation files
- Referenced content ID check for updated/new curation files
- pre-commit hooks on commits

## Notes

- `xcodebuild -workspace ios-monorepo.xcworkspace -scheme LekaApp -destination 'generic/platform=iOS Simulator' -configuration Debug build CODE_SIGNING_ALLOWED=NO` currently fails because the generated project references missing existing asset `Modules/ContentKit/Resources/Content/resources/illustrations/accessories_pack.resource.icon.png`.\n