### PR TITLE
🐛 Fix robot action button drift

### DIFF
--- a/Modules/ContentKit/Sources/GameEngine/Interfaces/DnD/Grid/DnDGridView.swift
+++ b/Modules/ContentKit/Sources/GameEngine/Interfaces/DnD/Grid/DnDGridView.swift
@@ -19,26 +19,11 @@ public struct DnDGridView: View {
     public var body: some View {
         HStack(spacing: 0) {
             if let action = self.viewModel.action {
-                Button {
-                    // nothing to do
+                ActionButtonColumn(action: action) {
+                    withAnimation {
+                        self.viewModel.didTriggerAction = true
+                    }
                 }
-                label: {
-                    ActionButtonView(action: action)
-                        .padding(20)
-                }
-                .simultaneousGesture(
-                    TapGesture()
-                        .onEnded { _ in
-                            withAnimation {
-                                self.viewModel.didTriggerAction = true
-                            }
-                        }
-                )
-
-                Divider()
-                    .opacity(0.4)
-                    .frame(maxHeight: 500)
-                    .padding(.vertical, 20)
             }
 
             GeometryReader { proxy in

--- a/Modules/ContentKit/Sources/GameEngine/Interfaces/DnD/GridWithZones/DnDGridWithZonesView.swift
+++ b/Modules/ContentKit/Sources/GameEngine/Interfaces/DnD/GridWithZones/DnDGridWithZonesView.swift
@@ -21,26 +21,11 @@ public struct DnDGridWithZonesView: View {
         ZStack(alignment: .bottomTrailing) {
             HStack(spacing: 0) {
                 if let action = self.viewModel.action {
-                    Button {
-                        // nothing to do
+                    ActionButtonColumn(action: action) {
+                        withAnimation {
+                            self.viewModel.didTriggerAction = true
+                        }
                     }
-                    label: {
-                        ActionButtonView(action: action)
-                            .padding(20)
-                    }
-                    .simultaneousGesture(
-                        TapGesture()
-                            .onEnded { _ in
-                                withAnimation {
-                                    self.viewModel.didTriggerAction = true
-                                }
-                            }
-                    )
-
-                    Divider()
-                        .opacity(0.4)
-                        .frame(maxHeight: 500)
-                        .padding(.vertical, 20)
                 }
 
                 GeometryReader { proxy in

--- a/Modules/ContentKit/Sources/GameEngine/Interfaces/DnD/OneToOne/DnDOneToOneView.swift
+++ b/Modules/ContentKit/Sources/GameEngine/Interfaces/DnD/OneToOne/DnDOneToOneView.swift
@@ -21,26 +21,11 @@ public struct DnDOneToOneView: View {
         ZStack(alignment: .bottomTrailing) {
             HStack(spacing: 0) {
                 if let action = self.viewModel.action {
-                    Button {
-                        // nothing to do
+                    ActionButtonColumn(action: action) {
+                        withAnimation {
+                            self.viewModel.didTriggerAction = true
+                        }
                     }
-                    label: {
-                        ActionButtonView(action: action)
-                            .padding(20)
-                    }
-                    .simultaneousGesture(
-                        TapGesture()
-                            .onEnded { _ in
-                                withAnimation {
-                                    self.viewModel.didTriggerAction = true
-                                }
-                            }
-                    )
-
-                    Divider()
-                        .opacity(0.4)
-                        .frame(maxHeight: 500)
-                        .padding(.vertical, 20)
                 }
 
                 GeometryReader { proxy in

--- a/Modules/ContentKit/Sources/GameEngine/Interfaces/MagicCard/MagicCardView.swift
+++ b/Modules/ContentKit/Sources/GameEngine/Interfaces/MagicCard/MagicCardView.swift
@@ -24,27 +24,12 @@ public struct MagicCardView: View {
         ZStack {
             HStack(spacing: 0) {
                 if let action = self.viewModel.action {
-                    Button {
-                        // nothing to do
+                    ActionButtonColumn(action: action) {
+                        withAnimation {
+                            self.viewModel.didTriggerAction = true
+                            self.viewModel.enableMagicCardDetection()
+                        }
                     }
-                    label: {
-                        ActionButtonView(action: action)
-                            .padding(20)
-                    }
-                    .simultaneousGesture(
-                        TapGesture()
-                            .onEnded { _ in
-                                withAnimation {
-                                    self.viewModel.didTriggerAction = true
-                                    self.viewModel.enableMagicCardDetection()
-                                }
-                            }
-                    )
-
-                    Divider()
-                        .opacity(0.4)
-                        .frame(maxHeight: 500)
-                        .padding(.vertical, 20)
                 }
 
                 Group {

--- a/Modules/ContentKit/Sources/GameEngine/Interfaces/NewSpecialized/SuperSimon/NewSuperSimonView.swift
+++ b/Modules/ContentKit/Sources/GameEngine/Interfaces/NewSpecialized/SuperSimon/NewSuperSimonView.swift
@@ -28,41 +28,37 @@ struct NewSuperSimonView: View {
         let interface = Interface(rawValue: viewModel.choices.count)
         ZStack {
             HStack(spacing: 0) {
-                ZStack {
-                    ActionButtonView.ActionButtonPulse(isPulsing: self.viewModel.isPulsing)
+                StableActionColumn {
+                    ZStack {
+                        ActionButtonView.ActionButtonPulse(isPulsing: self.viewModel.isPulsing)
 
-                    Button {
-                        self.viewModel.onRobotTapped()
-                    } label: {
-                        Image(uiImage: DesignKitAsset.Images.robotFaceAction.image)
-                            .resizable()
-                            .renderingMode(.template)
-                            .foregroundStyle(self.styleManager.accentColor!)
-                            .frame(width: 130, height: 130)
-                            .padding(10)
+                        Button {
+                            self.viewModel.onRobotTapped()
+                        } label: {
+                            Image(uiImage: DesignKitAsset.Images.robotFaceAction.image)
+                                .resizable()
+                                .renderingMode(.template)
+                                .foregroundStyle(self.styleManager.accentColor!)
+                                .frame(width: 130, height: 130)
+                                .padding(10)
+                        }
+                        .frame(width: 200, height: 200)
+                        .disabled(self.viewModel.disableRobot)
+                        .opacity(self.viewModel.disableRobot ? 0.3 : 1.0)
+                        .buttonStyle(ActionButtonStyle(progress: 0.0))
+                        .scaleEffect(self.viewModel.disableRobot ? 0.95 : 1.0, anchor: .center)
+                        .scaleEffect(self.viewModel.isPulsing ? 1.1 : 1.0, anchor: .center)
+                        .animation(self.viewModel.isPulsing ?
+                            .easeInOut(duration: 1).repeatForever(autoreverses: true).speed(1.2) :
+                            .easeInOut(duration: 1),
+                            value: self.viewModel.isPulsing)
+                        .animation(.spring(response: 0.3, dampingFraction: 0.45), value: self.viewModel.disableRobot)
+                        .shadow(
+                            color: .accentColor.opacity(0.2),
+                            radius: self.viewModel.disableRobot ? 6 : 3, x: 0, y: 3
+                        )
                     }
-                    .frame(width: 200, height: 200)
-                    .disabled(self.viewModel.disableRobot)
-                    .opacity(self.viewModel.disableRobot ? 0.3 : 1.0)
-                    .buttonStyle(ActionButtonStyle(progress: 0.0))
-                    .scaleEffect(self.viewModel.disableRobot ? 0.95 : 1.0, anchor: .center)
-                    .scaleEffect(self.viewModel.isPulsing ? 1.1 : 1.0, anchor: .center)
-                    .animation(self.viewModel.isPulsing ?
-                        .easeInOut(duration: 1).repeatForever(autoreverses: true).speed(1.2) :
-                        .easeInOut(duration: 1),
-                        value: self.viewModel.isPulsing)
-                    .animation(.spring(response: 0.3, dampingFraction: 0.45), value: self.viewModel.disableRobot)
-                    .shadow(
-                        color: .accentColor.opacity(0.2),
-                        radius: self.viewModel.disableRobot ? 6 : 3, x: 0, y: 3
-                    )
-                    .padding(20)
                 }
-
-                Divider()
-                    .opacity(0.4)
-                    .frame(maxHeight: 500)
-                    .padding(.vertical, 20)
 
                 Group {
                     switch interface {

--- a/Modules/ContentKit/Sources/GameEngine/Interfaces/NewSpecialized/SuperSimon/NewSuperSimonView.swift
+++ b/Modules/ContentKit/Sources/GameEngine/Interfaces/NewSpecialized/SuperSimon/NewSuperSimonView.swift
@@ -47,11 +47,6 @@ struct NewSuperSimonView: View {
                         .opacity(self.viewModel.disableRobot ? 0.3 : 1.0)
                         .buttonStyle(ActionButtonStyle(progress: 0.0))
                         .scaleEffect(self.viewModel.disableRobot ? 0.95 : 1.0, anchor: .center)
-                        .scaleEffect(self.viewModel.isPulsing ? 1.1 : 1.0, anchor: .center)
-                        .animation(self.viewModel.isPulsing ?
-                            .easeInOut(duration: 1).repeatForever(autoreverses: true).speed(1.2) :
-                            .easeInOut(duration: 1),
-                            value: self.viewModel.isPulsing)
                         .animation(.spring(response: 0.3, dampingFraction: 0.45), value: self.viewModel.disableRobot)
                         .shadow(
                             color: .accentColor.opacity(0.2),

--- a/Modules/ContentKit/Sources/GameEngine/Interfaces/TTS/TTSView.swift
+++ b/Modules/ContentKit/Sources/GameEngine/Interfaces/TTS/TTSView.swift
@@ -22,26 +22,11 @@ public struct TTSView: View {
         ZStack(alignment: .bottomTrailing) {
             HStack(spacing: 0) {
                 if let action = self.viewModel.action {
-                    Button {
-                        // nothing to do
+                    ActionButtonColumn(action: action) {
+                        withAnimation {
+                            self.viewModel.didTriggerAction = true
+                        }
                     }
-                    label: {
-                        ActionButtonView(action: action)
-                            .padding(20)
-                    }
-                    .simultaneousGesture(
-                        TapGesture()
-                            .onEnded { _ in
-                                withAnimation {
-                                    self.viewModel.didTriggerAction = true
-                                }
-                            }
-                    )
-
-                    Divider()
-                        .opacity(0.4)
-                        .frame(maxHeight: 500)
-                        .padding(.vertical, 20)
                 }
 
                 Group {

--- a/Modules/ContentKit/Sources/GameEngine/Views/Buttons/ActionButton/ActionButtonView+Listen.swift
+++ b/Modules/ContentKit/Sources/GameEngine/Views/Buttons/ActionButton/ActionButtonView+Listen.swift
@@ -38,15 +38,11 @@ extension ActionButtonView {
                 .disabled(self.isPlaying)
                 .buttonStyle(Style(progress: self.isPlaying ? self.audioManagerViewModel.progress.percentage : 0))
                 .scaleEffect(self.isPlaying ? 1.0 : 0.8, anchor: .center)
-                .scaleEffect(self.isPulsing ? 1.1 : 1.0, anchor: .center)
                 .shadow(
                     color: self.styleManager.accentColor!.opacity(0.2),
                     radius: self.isPlaying ? 6 : 3, x: 0, y: 3
                 )
                 .animation(.spring(response: 0.3, dampingFraction: 0.45), value: self.isPlaying)
-                .animation(self.isPulsing ?
-                    .easeInOut(duration: 1).repeatForever(autoreverses: true).speed(1.2) :
-                    .easeInOut(duration: 1), value: self.isPulsing)
                 .onDisappear {
                     self.audioManager.stop()
                 }

--- a/Modules/ContentKit/Sources/GameEngine/Views/Buttons/ActionButton/ActionButtonView+Robot.swift
+++ b/Modules/ContentKit/Sources/GameEngine/Views/Buttons/ActionButton/ActionButtonView+Robot.swift
@@ -60,9 +60,7 @@ extension ActionButtonView {
                 .opacity(self.robotWasTapped ? 0.3 : 1.0)
                 .buttonStyle(Style(progress: 0.0))
                 .scaleEffect(self.robotWasTapped ? 0.95 : 1.0, anchor: .center)
-                .scaleEffect(self.isPulsing ? 1.1 : 1.0, anchor: .center)
                 .animation(.spring(response: 0.3, dampingFraction: 0.45), value: self.robotWasTapped)
-                .animation(self.isPulsing ? .easeInOut(duration: 1).repeatForever(autoreverses: true).speed(1.2) : .easeInOut(duration: 1), value: self.isPulsing)
                 .shadow(
                     color: self.styleManager.accentColor!.opacity(0.2),
                     radius: self.robotWasTapped ? 6 : 3, x: 0, y: 3

--- a/Modules/ContentKit/Sources/GameEngine/Views/Buttons/ActionButton/StableActionColumn.swift
+++ b/Modules/ContentKit/Sources/GameEngine/Views/Buttons/ActionButton/StableActionColumn.swift
@@ -1,0 +1,84 @@
+// Leka - iOS Monorepo
+// Copyright APF France handicap
+// SPDX-License-Identifier: Apache-2.0
+
+import SwiftUI
+
+// MARK: - StableActionColumn
+
+struct StableActionColumn<Content: View>: View {
+    // MARK: Lifecycle
+
+    init(onTap: (() -> Void)? = nil, @ViewBuilder content: @escaping () -> Content) {
+        self.onTap = onTap
+        self.content = content
+    }
+
+    // MARK: Internal
+
+    var body: some View {
+        HStack(spacing: 0) {
+            self.actionFootprint
+
+            Divider()
+                .opacity(0.4)
+                .frame(maxHeight: 500)
+                .padding(.vertical, 20)
+        }
+    }
+
+    // MARK: Private
+
+    private static var minimumFootprint: CGFloat { 260 }
+    private static var contentPadding: CGFloat { 20 }
+
+    private let onTap: (() -> Void)?
+    private let content: () -> Content
+
+    @ViewBuilder private var actionFootprint: some View {
+        let footprint = self.content()
+            .padding(Self.contentPadding)
+            .frame(
+                minWidth: Self.minimumFootprint,
+                minHeight: Self.minimumFootprint,
+                alignment: .center
+            )
+
+        if let onTap = self.onTap {
+            footprint
+                .contentShape(Rectangle())
+                .simultaneousGesture(
+                    TapGesture()
+                        .onEnded { _ in
+                            onTap()
+                        }
+                )
+        } else {
+            footprint
+        }
+    }
+}
+
+// MARK: - ActionButtonColumn
+
+struct ActionButtonColumn: View {
+    // MARK: Lifecycle
+
+    init(action: NewExerciseAction, onActionTriggered: @escaping () -> Void) {
+        self.action = action
+        self.onActionTriggered = onActionTriggered
+    }
+
+    // MARK: Internal
+
+    var body: some View {
+        StableActionColumn(onTap: self.onActionTriggered) {
+            ActionButtonView(action: self.action)
+        }
+    }
+
+    // MARK: Private
+
+    private let action: NewExerciseAction
+    private let onActionTriggered: () -> Void
+}


### PR DESCRIPTION
## Summary
- Add a reusable stable action column for exercise action gates
- Replace nested placeholder action buttons in Magic Card, TTS, and DnD interfaces
- Reuse the same stable footprint for Super Simon's custom robot control

## Verification
- swiftformat --lint targeted files
- swiftlint lint targeted files
- xcodebuild build -workspace ios-monorepo.xcworkspace -scheme ContentKit -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO

closes #2057
closes #2058
closes #2059
closes #2060
closes #2061
closes #2062
closes #2063